### PR TITLE
feat: add simulatest-di-quarkus plugin with Arc-native environments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 		<module>simulatest-gui</module>
 		<module>simulatest-di-jee</module>
 		<module>simulatest-di-guice</module>
+		<module>simulatest-di-quarkus</module>
 	</modules>
 
 	<developers>

--- a/simulatest-di-quarkus/pom.xml
+++ b/simulatest-di-quarkus/pom.xml
@@ -20,6 +20,10 @@
 		lifecycle.
 	</description>
 
+	<properties>
+		<quarkus.version>3.30.1</quarkus.version>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.simulatest</groupId>
@@ -29,20 +33,29 @@
 			<groupId>org.simulatest</groupId>
 			<artifactId>simulatest-insistencelayer</artifactId>
 		</dependency>
-
-		<!-- Test-scope dependencies. A full Quarkus + Panache end-to-end test
-		     lives in the simulatest-examples repo, where the Quarkus Maven
-		     plugin is already on the build. -->
 		<dependency>
 			<groupId>org.simulatest</groupId>
 			<artifactId>simulatest-environment-junit-platform</artifactId>
-			<scope>test</scope>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!-- Quarkus Arc and JUnit Jupiter are compile-visible APIs; downstream
+		     Quarkus test projects always supply them, so they stay provided. -->
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-arc</artifactId>
+			<version>${quarkus.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<scope>test</scope>
+			<scope>provided</scope>
 		</dependency>
+
+		<!-- Test-scope dependencies. A full Quarkus + Panache end-to-end test
+		     lives in the simulatest-examples repo, where the Quarkus Maven
+		     plugin is already on the build. -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>

--- a/simulatest-di-quarkus/pom.xml
+++ b/simulatest-di-quarkus/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.simulatest</groupId>
+		<artifactId>simulatest</artifactId>
+		<version>0.1.0</version>
+	</parent>
+
+	<artifactId>simulatest-di-quarkus</artifactId>
+	<name>Simulatest - DI Quarkus Plugin</name>
+	<description>
+		Bootstraps Simulatest's Insistence Layer for use with Quarkus and
+		Panache. Environments use plain JDBC through the wrapped DataSource;
+		test methods use Panache/Arc through Quarkus's normal @QuarkusTest
+		lifecycle.
+	</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.simulatest</groupId>
+			<artifactId>simulatest-environment-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.simulatest</groupId>
+			<artifactId>simulatest-insistencelayer</artifactId>
+		</dependency>
+
+		<!-- Test-scope dependencies. A full Quarkus + Panache end-to-end test
+		     lives in the simulatest-examples repo, where the Quarkus Maven
+		     plugin is already on the build. -->
+		<dependency>
+			<groupId>org.simulatest</groupId>
+			<artifactId>simulatest-environment-junit-platform</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/simulatest-di-quarkus/pom.xml
+++ b/simulatest-di-quarkus/pom.xml
@@ -36,7 +36,6 @@
 		<dependency>
 			<groupId>org.simulatest</groupId>
 			<artifactId>simulatest-environment-junit-platform</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 
 		<!-- Quarkus Arc and JUnit Jupiter are compile-visible APIs; downstream

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/DriverBackedDataSource.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/DriverBackedDataSource.java
@@ -1,0 +1,67 @@
+package org.simulatest.di.quarkus;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import javax.sql.DataSource;
+
+/**
+ * Minimal {@link DataSource} that opens {@link Connection}s via
+ * {@link DriverManager} using a fixed JDBC URL. Used only by the driver-only
+ * bootstrap path; not intended as a general-purpose {@code DataSource}.
+ */
+final class DriverBackedDataSource implements DataSource {
+
+	private final String url;
+	private final Properties properties;
+
+	DriverBackedDataSource(String url, Properties properties) {
+		this.url = Objects.requireNonNull(url, "url must not be null");
+		// Defensive copy: the caller may keep a reference to the Properties
+		// object and mutate credentials afterwards; we want a stable snapshot.
+		Properties snapshot = new Properties();
+		if (properties != null) snapshot.putAll(properties);
+		this.properties = snapshot;
+	}
+
+	@Override
+	public Connection getConnection() throws SQLException {
+		return DriverManager.getConnection(url, properties);
+	}
+
+	@Override
+	public Connection getConnection(String user, String password) throws SQLException {
+		Properties merged = new Properties();
+		merged.putAll(properties);
+		if (user != null)     merged.setProperty("user", user);
+		if (password != null) merged.setProperty("password", password);
+		return DriverManager.getConnection(url, merged);
+	}
+
+	@Override public PrintWriter getLogWriter()          { return null; }
+	@Override public void setLogWriter(PrintWriter out)   { /* no-op */ }
+	@Override public int getLoginTimeout()                { return 0; }
+	@Override public void setLoginTimeout(int seconds)    { /* no-op */ }
+
+	@Override
+	public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+		throw new SQLFeatureNotSupportedException();
+	}
+
+	@Override
+	public <T> T unwrap(Class<T> iface) throws SQLException {
+		throw new SQLException("DriverBackedDataSource does not wrap anything");
+	}
+
+	@Override
+	public boolean isWrapperFor(Class<?> iface) {
+		return false;
+	}
+
+}

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/DriverBackedDataSource.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/DriverBackedDataSource.java
@@ -56,12 +56,13 @@ final class DriverBackedDataSource implements DataSource {
 
 	@Override
 	public <T> T unwrap(Class<T> iface) throws SQLException {
-		throw new SQLException("DriverBackedDataSource does not wrap anything");
+		if (iface.isInstance(this)) return iface.cast(this);
+		throw new SQLException(getClass().getName() + " is not a wrapper for " + iface.getName());
 	}
 
 	@Override
 	public boolean isWrapperFor(Class<?> iface) {
-		return false;
+		return iface.isInstance(this);
 	}
 
 }

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/QuarkusEnvironmentJupiterExtension.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/QuarkusEnvironmentJupiterExtension.java
@@ -37,11 +37,18 @@ public final class QuarkusEnvironmentJupiterExtension implements BeforeAllCallba
 
 	private static final Logger logger = LoggerFactory.getLogger(QuarkusEnvironmentJupiterExtension.class);
 
-	// Identity of the Arc container we saw on the previous beforeAll. Different
-	// instance means Quarkus restarted (e.g., @TestProfile switch), and every
-	// previously-claimed environment is now against a runtime that no longer
-	// exists — reset the coordinator so ancestors re-run against the new one.
+	// Different instance on the next beforeAll means Quarkus restarted
+	// (e.g. @TestProfile switch); we reset the coordinator in that case.
 	private static ArcContainer lastKnownContainer;
+
+	/**
+	 * Clears the cached Arc container reference. Called from
+	 * {@link SimulatestQuarkusPlugin#destroy()} so a long-lived JVM running
+	 * multiple sessions doesn't retain the final container of each session.
+	 */
+	static synchronized void forgetLastKnownContainer() {
+		lastKnownContainer = null;
+	}
 
 	@Override
 	public void beforeAll(ExtensionContext context) {

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/QuarkusEnvironmentJupiterExtension.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/QuarkusEnvironmentJupiterExtension.java
@@ -12,6 +12,8 @@ import org.simulatest.environment.Environment;
 import org.simulatest.environment.junit5.DeferredEnvironmentCoordinator;
 import org.simulatest.insistencelayer.InsistenceLayer;
 import org.simulatest.insistencelayer.InsistenceLayerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Jupiter extension that runs the deferred environments for a test class
@@ -33,8 +35,18 @@ import org.simulatest.insistencelayer.InsistenceLayerFactory;
  */
 public final class QuarkusEnvironmentJupiterExtension implements BeforeAllCallback {
 
+	private static final Logger logger = LoggerFactory.getLogger(QuarkusEnvironmentJupiterExtension.class);
+
+	// Identity of the Arc container we saw on the previous beforeAll. Different
+	// instance means Quarkus restarted (e.g., @TestProfile switch), and every
+	// previously-claimed environment is now against a runtime that no longer
+	// exists — reset the coordinator so ancestors re-run against the new one.
+	private static ArcContainer lastKnownContainer;
+
 	@Override
 	public void beforeAll(ExtensionContext context) {
+		resetCoordinatorIfQuarkusRestarted();
+
 		Class<?> testClass = context.getRequiredTestClass();
 		List<Class<? extends Environment>> ancestry = DeferredEnvironmentCoordinator.ancestryOf(testClass);
 		if (ancestry.isEmpty()) return;
@@ -45,14 +57,51 @@ public final class QuarkusEnvironmentJupiterExtension implements BeforeAllCallba
 
 		for (Class<? extends Environment> environmentClass : ancestry) {
 			if (!DeferredEnvironmentCoordinator.claimNotYetRun(environmentClass)) continue;
+			runAndPushOrRollbackClaim(environmentClass, layer);
+		}
+	}
+
+	private static synchronized void resetCoordinatorIfQuarkusRestarted() {
+		ArcContainer current = currentArcContainer();
+		if (current == null || current == lastKnownContainer) return;
+		if (lastKnownContainer != null) {
+			logger.info("Arc container changed identity (likely @TestProfile switch); clearing deferred-environment tracking");
+			DeferredEnvironmentCoordinator.reset();
+		}
+		lastKnownContainer = current;
+	}
+
+	private static ArcContainer currentArcContainer() {
+		try {
+			return Arc.container();
+		} catch (RuntimeException absent) {
+			return null;
+		}
+	}
+
+	// If the env's run() or the savepoint push fails, release the claim so
+	// subsequent test classes can retry rather than silently skip on a stale
+	// record. Propagate the original throwable so Jupiter fails this class
+	// with the real cause.
+	private static void runAndPushOrRollbackClaim(Class<? extends Environment> environmentClass, InsistenceLayer layer) {
+		try {
 			runEnvironment(environmentClass);
 			layer.increaseLevel();
+		} catch (Throwable propagate) {
+			DeferredEnvironmentCoordinator.forget(environmentClass);
+			throw propagate;
 		}
 	}
 
 	private static void runEnvironment(Class<? extends Environment> environmentClass) {
 		Environment environment = resolveFromArc(environmentClass);
-		if (environment == null) environment = reflectivelyInstantiate(environmentClass);
+		if (environment == null) {
+			logger.warn(
+				"{} is not a discovered Arc bean; falling back to reflection. Add @Dependent or "
+				+ "@ApplicationScoped if the environment uses @Inject fields, otherwise they will be null.",
+				environmentClass.getName());
+			environment = reflectivelyInstantiate(environmentClass);
+		}
 		environment.run();
 	}
 
@@ -61,8 +110,16 @@ public final class QuarkusEnvironmentJupiterExtension implements BeforeAllCallba
 	// to reflection, matching the behavior the other DI plugins' environment
 	// factories already expose.
 	private static Environment resolveFromArc(Class<? extends Environment> environmentClass) {
-		ArcContainer container = Arc.container();
+		ArcContainer container;
+		try {
+			container = Arc.container();
+		} catch (RuntimeException absent) {
+			// Container can be null or throw while Arc is in an in-between
+			// state. Treat both uniformly: drop to reflection.
+			return null;
+		}
 		if (container == null) return null;
+
 		InstanceHandle<? extends Environment> handle = container.instance(environmentClass);
 		return handle.isAvailable() ? handle.get() : null;
 	}

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/QuarkusEnvironmentJupiterExtension.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/QuarkusEnvironmentJupiterExtension.java
@@ -32,6 +32,10 @@ import org.slf4j.LoggerFactory;
  * {@code @Inject} fields are populated), invokes {@code run()}, and pushes
  * an Insistence Layer level. A sibling test class entering later sees the
  * already-claimed ancestors and only runs its own leaf environment.
+ *
+ * <p>When a new Arc container is observed (typically a {@code @TestProfile}
+ * switch), any savepoints pushed under the old container are unwound and
+ * the coordinator is reset, so the new runtime starts from a clean stack.
  */
 public final class QuarkusEnvironmentJupiterExtension implements BeforeAllCallback {
 
@@ -52,7 +56,7 @@ public final class QuarkusEnvironmentJupiterExtension implements BeforeAllCallba
 
 	@Override
 	public void beforeAll(ExtensionContext context) {
-		resetCoordinatorIfQuarkusRestarted();
+		unwindStateIfQuarkusRestarted();
 
 		Class<?> testClass = context.getRequiredTestClass();
 		List<Class<? extends Environment>> ancestry = DeferredEnvironmentCoordinator.ancestryOf(testClass);
@@ -68,11 +72,18 @@ public final class QuarkusEnvironmentJupiterExtension implements BeforeAllCallba
 		}
 	}
 
-	private static synchronized void resetCoordinatorIfQuarkusRestarted() {
+	// Detects a new Arc container and unwinds both the logical (coordinator)
+	// and physical (savepoint stack) state belonging to the previous one.
+	// Without the physical unwind, levels pushed under the old Arc would remain
+	// on the connection; the coordinator would then claim ancestors freshly and
+	// push again on top, corrupting rollback boundaries for the rest of the
+	// suite.
+	private static synchronized void unwindStateIfQuarkusRestarted() {
 		ArcContainer current = currentArcContainer();
 		if (current == null || current == lastKnownContainer) return;
 		if (lastKnownContainer != null) {
-			logger.info("Arc container changed identity (likely @TestProfile switch); clearing deferred-environment tracking");
+			logger.info("Arc container changed identity (likely @TestProfile switch); unwinding deferred-environment state");
+			InsistenceLayerFactory.resolve().ifPresent(layer -> layer.setLevelTo(0));
 			DeferredEnvironmentCoordinator.reset();
 		}
 		lastKnownContainer = current;
@@ -88,47 +99,54 @@ public final class QuarkusEnvironmentJupiterExtension implements BeforeAllCallba
 
 	// If the env's run() or the savepoint push fails, release the claim so
 	// subsequent test classes can retry rather than silently skip on a stale
-	// record. Propagate the original throwable so Jupiter fails this class
-	// with the real cause.
+	// record. The coordinator's push record is only set AFTER increaseLevel
+	// returns, so the matching onExit skips popping when a failure prevented
+	// the push from ever happening.
 	private static void runAndPushOrRollbackClaim(Class<? extends Environment> environmentClass, InsistenceLayer layer) {
 		try {
 			runEnvironment(environmentClass);
 			layer.increaseLevel();
+			DeferredEnvironmentCoordinator.recordPush(environmentClass);
 		} catch (Throwable propagate) {
 			DeferredEnvironmentCoordinator.forget(environmentClass);
 			throw propagate;
 		}
 	}
 
+	// Threads the Arc InstanceHandle through so @Dependent-scoped environments
+	// are properly destroyed after run() completes. For @ApplicationScoped and
+	// @Singleton beans close() is a no-op; for @Dependent it triggers the
+	// disposal chain that would otherwise leak the instance.
 	private static void runEnvironment(Class<? extends Environment> environmentClass) {
-		Environment environment = resolveFromArc(environmentClass);
-		if (environment == null) {
-			logger.warn(
-				"{} is not a discovered Arc bean; falling back to reflection. Add @Dependent or "
-				+ "@ApplicationScoped if the environment uses @Inject fields, otherwise they will be null.",
-				environmentClass.getName());
-			environment = reflectivelyInstantiate(environmentClass);
+		InstanceHandle<? extends Environment> arcHandle = resolveFromArc(environmentClass);
+		try {
+			Environment environment = arcHandle != null
+					? arcHandle.get()
+					: warnThenReflect(environmentClass);
+			environment.run();
+		} finally {
+			if (arcHandle != null) arcHandle.close();
 		}
-		environment.run();
 	}
 
-	// Arc returns null when the class isn't a discovered bean. That's a valid
-	// case for environments the user chose to leave un-annotated — we fall back
-	// to reflection, matching the behavior the other DI plugins' environment
-	// factories already expose.
-	private static Environment resolveFromArc(Class<? extends Environment> environmentClass) {
-		ArcContainer container;
-		try {
-			container = Arc.container();
-		} catch (RuntimeException absent) {
-			// Container can be null or throw while Arc is in an in-between
-			// state. Treat both uniformly: drop to reflection.
-			return null;
-		}
+	private static Environment warnThenReflect(Class<? extends Environment> environmentClass) {
+		logger.warn(
+			"{} is not a discovered Arc bean; falling back to reflection. Add @Dependent or "
+			+ "@ApplicationScoped if the environment uses @Inject fields, otherwise they will be null.",
+			environmentClass.getName());
+		return reflectivelyInstantiate(environmentClass);
+	}
+
+	private static InstanceHandle<? extends Environment> resolveFromArc(Class<? extends Environment> environmentClass) {
+		ArcContainer container = currentArcContainer();
 		if (container == null) return null;
 
 		InstanceHandle<? extends Environment> handle = container.instance(environmentClass);
-		return handle.isAvailable() ? handle.get() : null;
+		if (!handle.isAvailable()) {
+			handle.close();
+			return null;
+		}
+		return handle;
 	}
 
 	private static Environment reflectivelyInstantiate(Class<? extends Environment> environmentClass) {

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/QuarkusEnvironmentJupiterExtension.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/QuarkusEnvironmentJupiterExtension.java
@@ -1,0 +1,85 @@
+package org.simulatest.di.quarkus;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InstanceHandle;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.simulatest.environment.Environment;
+import org.simulatest.environment.junit5.DeferredEnvironmentCoordinator;
+import org.simulatest.insistencelayer.InsistenceLayer;
+import org.simulatest.insistencelayer.InsistenceLayerFactory;
+
+/**
+ * Jupiter extension that runs the deferred environments for a test class
+ * after Quarkus's Arc container has booted.
+ *
+ * <p>Registered for auto-detection via
+ * {@code META-INF/services/org.junit.jupiter.api.extension.Extension}; the
+ * inner Jupiter session that Simulatest launches for each test class has
+ * auto-detection enabled, so this fires without the user adding
+ * {@code @ExtendWith}.
+ *
+ * <p>Ordering: {@code QuarkusTestExtension#beforeAll} boots Arc. This
+ * extension's {@code beforeAll} runs afterwards, resolves the test class's
+ * environment ancestry from the {@code @UseEnvironment} chain, and for each
+ * ancestor not yet run in this suite instantiates it through Arc (so its
+ * {@code @Inject} fields are populated), invokes {@code run()}, and pushes
+ * an Insistence Layer level. A sibling test class entering later sees the
+ * already-claimed ancestors and only runs its own leaf environment.
+ */
+public final class QuarkusEnvironmentJupiterExtension implements BeforeAllCallback {
+
+	@Override
+	public void beforeAll(ExtensionContext context) {
+		Class<?> testClass = context.getRequiredTestClass();
+		List<Class<? extends Environment>> ancestry = DeferredEnvironmentCoordinator.ancestryOf(testClass);
+		if (ancestry.isEmpty()) return;
+
+		InsistenceLayer layer = InsistenceLayerFactory.resolve().orElseThrow(() -> new IllegalStateException(
+				"Insistence Layer is not configured. Ensure SimulatestQuarkusPlugin has initialized "
+				+ "before the test class enters Quarkus's lifecycle."));
+
+		for (Class<? extends Environment> environmentClass : ancestry) {
+			if (!DeferredEnvironmentCoordinator.claimNotYetRun(environmentClass)) continue;
+			runEnvironment(environmentClass);
+			layer.increaseLevel();
+		}
+	}
+
+	private static void runEnvironment(Class<? extends Environment> environmentClass) {
+		Environment environment = resolveFromArc(environmentClass);
+		if (environment == null) environment = reflectivelyInstantiate(environmentClass);
+		environment.run();
+	}
+
+	// Arc returns null when the class isn't a discovered bean. That's a valid
+	// case for environments the user chose to leave un-annotated — we fall back
+	// to reflection, matching the behavior the other DI plugins' environment
+	// factories already expose.
+	private static Environment resolveFromArc(Class<? extends Environment> environmentClass) {
+		ArcContainer container = Arc.container();
+		if (container == null) return null;
+		InstanceHandle<? extends Environment> handle = container.instance(environmentClass);
+		return handle.isAvailable() ? handle.get() : null;
+	}
+
+	private static Environment reflectivelyInstantiate(Class<? extends Environment> environmentClass) {
+		try {
+			var constructor = environmentClass.getDeclaredConstructor();
+			constructor.setAccessible(true);
+			return constructor.newInstance();
+		} catch (InvocationTargetException e) {
+			throw new IllegalStateException(
+					"Failed to instantiate environment " + environmentClass.getName(),
+					e.getCause() != null ? e.getCause() : e);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException(
+					"Failed to instantiate environment " + environmentClass.getName(), e);
+		}
+	}
+
+}

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/QuarkusSimulatestConfigurer.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/QuarkusSimulatestConfigurer.java
@@ -11,7 +11,10 @@ import javax.sql.DataSource;
  * One per test classpath is the expected case.
  *
  * <p>Typical implementation seeds an H2 in-memory database and runs CREATE
- * TABLE statements:
+ * TABLE statements. The example below needs the following imports:
+ * {@code javax.sql.DataSource}, {@code java.sql.Connection},
+ * {@code java.sql.Statement}, {@code java.sql.SQLException},
+ * {@code org.h2.jdbcx.JdbcDataSource}.
  *
  * <pre>
  * public final class MyConfigurer implements QuarkusSimulatestConfigurer {

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/QuarkusSimulatestConfigurer.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/QuarkusSimulatestConfigurer.java
@@ -1,0 +1,51 @@
+package org.simulatest.di.quarkus;
+
+import javax.sql.DataSource;
+
+/**
+ * User-provided hook that tells {@link SimulatestQuarkusPlugin} what
+ * {@link DataSource} to wrap and how to install the database schema.
+ *
+ * <p>Register an implementation via
+ * {@code META-INF/services/org.simulatest.di.quarkus.QuarkusSimulatestConfigurer}.
+ * One per test classpath is the expected case.
+ *
+ * <p>Typical implementation seeds an H2 in-memory database and runs CREATE
+ * TABLE statements:
+ *
+ * <pre>
+ * public final class MyConfigurer implements QuarkusSimulatestConfigurer {
+ *
+ *     &#064;Override public DataSource dataSource() {
+ *         JdbcDataSource h2 = new JdbcDataSource();
+ *         h2.setURL("jdbc:h2:mem:quarkus-test;DB_CLOSE_DELAY=-1");
+ *         return h2;
+ *     }
+ *
+ *     &#064;Override public void applySchema(DataSource wrapped) {
+ *         try (Connection c = wrapped.getConnection();
+ *              Statement s = c.createStatement()) {
+ *             s.execute("CREATE TABLE book (id BIGINT PRIMARY KEY, title VARCHAR(200))");
+ *         } catch (SQLException e) {
+ *             throw new IllegalStateException("schema failed", e);
+ *         }
+ *     }
+ * }
+ * </pre>
+ */
+public interface QuarkusSimulatestConfigurer {
+
+	/**
+	 * The raw {@link DataSource} to hand to the Insistence Layer. Must point at
+	 * the same database Quarkus-managed Hibernate will use.
+	 */
+	DataSource dataSource();
+
+	/**
+	 * Applies the schema to the (already Insistence-Layer-wrapped)
+	 * {@link DataSource}. Runs BEFORE any environment; DDL is safe here because
+	 * the wrapper hasn't yet pushed any savepoints.
+	 */
+	void applySchema(DataSource wrapped);
+
+}

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestInsistenceDriver.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestInsistenceDriver.java
@@ -27,6 +27,16 @@ import org.simulatest.insistencelayer.InsistenceLayerFactory;
  * <p>See {@link SimulatestQuarkusPlugin} for Quarkus configuration: required
  * Agroal pool sizing, parent-first classloading, and Hibernate dialect.
  *
+ * <h2>Single-configuration contract</h2>
+ *
+ * <p>The driver configures the Insistence Layer on its first successful
+ * connection and reuses that configuration for subsequent {@code connect()}
+ * calls. Calls with a different underlying URL fail fast with a
+ * {@link SQLException} rather than silently routing to the first-configured
+ * database. If the first connection attempt fails (e.g. bad credentials,
+ * temporary outage), no configuration is retained; a later call with valid
+ * parameters configures cleanly.
+ *
  * <h2>Database-specific behavior</h2>
  *
  * <p>Tested against H2 and PostgreSQL. Engines that cascade-release newer
@@ -39,6 +49,8 @@ public final class SimulatestInsistenceDriver implements Driver {
 
 	/** URL scheme prefix recognized by this driver. */
 	public static final String URL_PREFIX = "jdbc:simulatest:";
+
+	private static volatile String configuredUnderlyingUrl;
 
 	static {
 		try {
@@ -99,9 +111,25 @@ public final class SimulatestInsistenceDriver implements Driver {
 
 	// Synchronized so Agroal warm-up threads hitting connect() concurrently
 	// can't race into double initialization.
-	private static synchronized void ensureInsistenceLayerConfigured(String url, Properties info) {
-		if (InsistenceLayerFactory.isConfigured()) return;
-		InsistenceLayerFactory.configure(new DriverBackedDataSource(underlyingUrlOf(url), info));
+	//
+	// When isConfigured() is true, a mismatched URL fails fast rather than
+	// silently handing out a connection to the first-configured database.
+	//
+	// When the underlying DriverBackedDataSource fails to open (bad credentials,
+	// outage), InsistenceLayerRegistry.configure throws before mutating its
+	// state, so retrying with valid parameters later configures cleanly.
+	private static synchronized void ensureInsistenceLayerConfigured(String url, Properties info) throws SQLException {
+		String underlyingUrl = underlyingUrlOf(url);
+		if (InsistenceLayerFactory.isConfigured()) {
+			if (!underlyingUrl.equals(configuredUnderlyingUrl)) {
+				throw new SQLException(
+					"SimulatestInsistenceDriver was already configured for '" + configuredUnderlyingUrl
+					+ "'; cannot switch to '" + underlyingUrl + "' in the same JVM.");
+			}
+			return;
+		}
+		InsistenceLayerFactory.configure(new DriverBackedDataSource(underlyingUrl, info));
+		configuredUnderlyingUrl = underlyingUrl;
 	}
 
 	private static String underlyingUrlOf(String url) {

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestInsistenceDriver.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestInsistenceDriver.java
@@ -1,0 +1,111 @@
+package org.simulatest.di.quarkus;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import org.simulatest.insistencelayer.InsistenceLayerFactory;
+
+/**
+ * JDBC driver that routes every {@link Connection} through the Simulatest
+ * Insistence Layer. URLs take the form:
+ *
+ * <pre>
+ *   jdbc:simulatest:&lt;underlying-jdbc-url&gt;
+ * </pre>
+ *
+ * <p>e.g. {@code jdbc:simulatest:jdbc:h2:mem:app;DB_CLOSE_DELAY=-1}. The
+ * underlying URL is resolved to a real driver via {@link DriverManager}, a
+ * single physical connection is opened against it, and every {@code connect()}
+ * call returns the Insistence Layer's {@link Connection} proxy wrapping it.
+ *
+ * <p>See {@link SimulatestQuarkusPlugin} for Quarkus configuration: required
+ * Agroal pool sizing, parent-first classloading, and Hibernate dialect.
+ *
+ * <h2>Database-specific behavior</h2>
+ *
+ * <p>Tested against H2 and PostgreSQL. Engines that cascade-release newer
+ * savepoints when an older one is released (some older MySQL and Oracle
+ * versions) may surface edge cases around the translated-commit savepoint
+ * the Insistence Layer bumps on every {@code commit()}. Run the target
+ * engine through the library suite before adopting on it.
+ */
+public final class SimulatestInsistenceDriver implements Driver {
+
+	/** URL scheme prefix recognized by this driver. */
+	public static final String URL_PREFIX = "jdbc:simulatest:";
+
+	static {
+		try {
+			DriverManager.registerDriver(new SimulatestInsistenceDriver());
+		} catch (SQLException e) {
+			throw new ExceptionInInitializerError(e);
+		}
+	}
+
+	@Override
+	public Connection connect(String url, Properties info) throws SQLException {
+		if (!acceptsURL(url)) return null;
+		ensureInsistenceLayerConfigured(url, info);
+		return InsistenceLayerFactory.requireDataSource().getConnection();
+	}
+
+	@Override
+	public boolean acceptsURL(String url) {
+		return url != null && url.startsWith(URL_PREFIX);
+	}
+
+	@Override
+	public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+		if (!acceptsURL(url)) return new DriverPropertyInfo[0];
+
+		String underlyingUrl = underlyingUrlOf(url);
+		try {
+			return DriverManager.getDriver(underlyingUrl).getPropertyInfo(underlyingUrl, info);
+		} catch (SQLException unresolved) {
+			return new DriverPropertyInfo[0];
+		}
+	}
+
+	@Override
+	public int getMajorVersion() {
+		return 0;
+	}
+
+	@Override
+	public int getMinorVersion() {
+		return 1;
+	}
+
+	/**
+	 * Not JDBC-compliant in the strict sense: commits and rollbacks are
+	 * translated into Insistence Layer savepoint operations, which is a
+	 * deliberate deviation from pass-through JDBC semantics.
+	 */
+	@Override
+	public boolean jdbcCompliant() {
+		return false;
+	}
+
+	@Override
+	public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+		throw new SQLFeatureNotSupportedException();
+	}
+
+	// Synchronized so Agroal warm-up threads hitting connect() concurrently
+	// can't race into double initialization.
+	private static synchronized void ensureInsistenceLayerConfigured(String url, Properties info) {
+		if (InsistenceLayerFactory.isConfigured()) return;
+		InsistenceLayerFactory.configure(new DriverBackedDataSource(underlyingUrlOf(url), info));
+	}
+
+	private static String underlyingUrlOf(String url) {
+		return url.substring(URL_PREFIX.length());
+	}
+
+}

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestQuarkusPlugin.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestQuarkusPlugin.java
@@ -1,0 +1,171 @@
+package org.simulatest.di.quarkus;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+import javax.sql.DataSource;
+
+import org.simulatest.environment.plugin.SimulatestPlugin;
+import org.simulatest.insistencelayer.InsistenceLayerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simulatest plugin for Quarkus + Panache test suites.
+ *
+ * <h2>Responsibilities</h2>
+ *
+ * <p>This plugin handles exactly the two things that must happen before
+ * Simulatest's environment tree walks and before Quarkus boots:
+ * <ol>
+ *   <li>Discover a {@link QuarkusSimulatestConfigurer} on the classpath via
+ *       {@link ServiceLoader}, wrap the {@link DataSource} it supplies with
+ *       the Insistence Layer, and register it in
+ *       {@link InsistenceLayerFactory}.</li>
+ *   <li>Apply the user-supplied schema DDL to the wrapped data source, so
+ *       tables exist before any environment tries to insert rows.</li>
+ * </ol>
+ *
+ * <h2>What it deliberately does NOT do</h2>
+ *
+ * <p>This plugin does not bootstrap Arc or Quarkus. Quarkus starts on its
+ * own schedule when a {@code @QuarkusTest}-annotated class enters its
+ * {@code beforeAll} phase. By then the Insistence Layer is already
+ * configured and the schema already exists, so Quarkus-managed Hibernate
+ * can initialize cleanly.
+ *
+ * <p>Connections are routed through the Insistence Layer at the JDBC driver
+ * layer — see {@link SimulatestInsistenceDriver}. Agroal operates on its
+ * usual {@code DataSource}; every connection it hands out is already
+ * Insistence-Layer-wrapped because the driver is what created it.
+ *
+ * <h2>What the user still has to configure</h2>
+ *
+ * <p>In {@code application.properties}, Hibernate cannot auto-detect a
+ * dialect when {@code db-kind=other}, so set it explicitly:
+ *
+ * <pre>
+ * # Required: Hibernate dialect must match the underlying database
+ * quarkus.hibernate-orm.dialect=H2
+ * quarkus.hibernate-orm.database.generation=none
+ *
+ * # Data source wiring
+ * quarkus.datasource.db-kind=other
+ * quarkus.datasource.jdbc.driver=org.simulatest.di.quarkus.SimulatestInsistenceDriver
+ * quarkus.datasource.jdbc.url=jdbc:simulatest:jdbc:h2:mem:app;DB_CLOSE_DELAY=-1
+ * quarkus.datasource.jdbc.min-size=1
+ * quarkus.datasource.jdbc.max-size=1
+ * quarkus.datasource.jdbc.initial-size=1
+ *
+ * # Classloading: share the Insistence Layer registry across classloaders
+ * quarkus.class-loading.parent-first-artifacts=\
+ *     org.simulatest:simulatest-insistencelayer,\
+ *     org.simulatest:simulatest-di-quarkus
+ *
+ * # Disable Dev Services so they don't spin up their own datasource
+ * quarkus.devservices.enabled=false
+ * </pre>
+ *
+ * <p>The user must also add {@code org.simulatest:simulatest-di-quarkus} to
+ * the test classpath and provide a {@link QuarkusSimulatestConfigurer}
+ * registered via {@code META-INF/services}. Exactly one configurer is
+ * required; zero or more than one causes startup to fail with a diagnostic
+ * error rather than surface confusing downstream failures.
+ *
+ * <h2>Thread-safety</h2>
+ *
+ * <p>Not thread-safe. Initialize and destroy from the owning test thread.
+ * Inherits the Insistence Layer's single-thread constraint.
+ */
+public final class SimulatestQuarkusPlugin implements SimulatestPlugin {
+
+	private static final Logger logger = LoggerFactory.getLogger(SimulatestQuarkusPlugin.class);
+
+	@Override
+	public void initialize(Collection<Class<?>> testClasses) {
+		if (InsistenceLayerFactory.isConfigured()) {
+			logger.info("InsistenceLayer already configured; skipping bootstrap");
+			return;
+		}
+
+		logClassloaderContext();
+		apply(requireExactlyOneConfigurer(loadConfigurers()));
+	}
+
+	/**
+	 * Validates discovery found exactly one configurer and returns it. Throws
+	 * {@link IllegalStateException} with a diagnostic message on zero or more
+	 * than one, turning a silent misconfiguration into a loud, actionable
+	 * failure at plugin-init time rather than a confusing
+	 * {@code requireDataSource()} error during the first environment.
+	 *
+	 * <p>Package-private for direct testing of the validation paths without
+	 * having to simulate {@code ServiceLoader} behavior.
+	 */
+	static QuarkusSimulatestConfigurer requireExactlyOneConfigurer(
+			List<QuarkusSimulatestConfigurer> configurers) {
+		if (configurers.isEmpty()) {
+			throw new IllegalStateException(
+				"No " + QuarkusSimulatestConfigurer.class.getSimpleName() + " was found on the classpath. "
+				+ "Register one via META-INF/services/" + QuarkusSimulatestConfigurer.class.getName() + ".");
+		}
+		if (configurers.size() > 1) {
+			String names = configurers.stream()
+					.map(c -> c.getClass().getName())
+					.collect(Collectors.joining(", "));
+			throw new IllegalStateException(
+				"Multiple " + QuarkusSimulatestConfigurer.class.getSimpleName() + " implementations found: "
+				+ names + ". Exactly one is required.");
+		}
+		return configurers.get(0);
+	}
+
+	private void apply(QuarkusSimulatestConfigurer configurer) {
+		DataSource rawDataSource = configurer.dataSource();
+		InsistenceLayerFactory.configure(rawDataSource);
+
+		// Schema application runs BEFORE any environment, and therefore before
+		// ConnectionWrapper.wrap() sets autoCommit=false. DDL at this point is
+		// safe: no savepoint stack exists yet to invalidate.
+		DataSource wrapped = InsistenceLayerFactory.requireDataSource();
+		configurer.applySchema(wrapped);
+
+		logger.info("Simulatest Quarkus plugin initialized via {}", configurer.getClass().getName());
+	}
+
+	// Emits the classloader identity of InsistenceLayerFactory at INFO. When a
+	// Quarkus test run misbehaves with phantom isolation failures, this log
+	// line lets a diagnostician verify at a glance that the parent-first
+	// classloading configuration is in effect.
+	private void logClassloaderContext() {
+		ClassLoader factoryCl = InsistenceLayerFactory.class.getClassLoader();
+		ClassLoader pluginCl  = getClass().getClassLoader();
+		if (factoryCl == pluginCl) {
+			logger.info("InsistenceLayerFactory loaded by plugin classloader {}", factoryCl);
+		} else {
+			logger.info(
+				"InsistenceLayerFactory classloader ({}) differs from plugin classloader ({}). "
+				+ "Confirm quarkus.class-loading.parent-first-artifacts includes simulatest-insistencelayer.",
+				factoryCl, pluginCl);
+		}
+	}
+
+	private static List<QuarkusSimulatestConfigurer> loadConfigurers() {
+		return ServiceLoader.load(QuarkusSimulatestConfigurer.class).stream()
+				.map(ServiceLoader.Provider::get)
+				.toList();
+	}
+
+	/**
+	 * Clears the Insistence Layer registry so the next test run starts from a
+	 * clean slate, which matters when multiple test sessions share one JVM
+	 * and/or different {@code @TestProfile}s demand different schemas.
+	 */
+	@Override
+	public void destroy() {
+		InsistenceLayerFactory.clear();
+	}
+
+}

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestQuarkusPlugin.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestQuarkusPlugin.java
@@ -142,8 +142,17 @@ public final class SimulatestQuarkusPlugin implements SimulatestPlugin {
 		// Schema application runs BEFORE any environment, and therefore before
 		// ConnectionWrapper.wrap() sets autoCommit=false. DDL at this point is
 		// safe: no savepoint stack exists yet to invalidate.
+		//
+		// If schema application fails, unwind the Insistence Layer registration
+		// so a subsequent initialize() can retry cleanly instead of being
+		// short-circuited by the isConfigured() guard at the top.
 		DataSource wrapped = InsistenceLayerFactory.requireDataSource();
-		configurer.applySchema(wrapped);
+		try {
+			configurer.applySchema(wrapped);
+		} catch (RuntimeException fault) {
+			InsistenceLayerFactory.clear();
+			throw fault;
+		}
 
 		logger.info("Simulatest Quarkus plugin initialized via {}", configurer.getClass().getName());
 	}

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestQuarkusPlugin.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestQuarkusPlugin.java
@@ -7,6 +7,9 @@ import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
+import org.simulatest.environment.junit5.DeferredEnvironmentCoordinator;
+import org.simulatest.environment.junit5.DeferredEnvironmentLifecycle;
+import org.simulatest.environment.plugin.EnvironmentLifecycle;
 import org.simulatest.environment.plugin.SimulatestPlugin;
 import org.simulatest.insistencelayer.InsistenceLayerFactory;
 import org.slf4j.Logger;
@@ -159,13 +162,24 @@ public final class SimulatestQuarkusPlugin implements SimulatestPlugin {
 	}
 
 	/**
-	 * Clears the Insistence Layer registry so the next test run starts from a
-	 * clean slate, which matters when multiple test sessions share one JVM
-	 * and/or different {@code @TestProfile}s demand different schemas.
+	 * Contributes the deferred lifecycle so the engine's tree walk becomes a
+	 * no-op for env run and savepoint push; {@link QuarkusEnvironmentJupiterExtension}
+	 * does that work after Arc has booted inside the inner Jupiter session.
+	 */
+	@Override
+	public EnvironmentLifecycle environmentLifecycle() {
+		return new DeferredEnvironmentLifecycle();
+	}
+
+	/**
+	 * Clears suite-wide state so the next test run starts from a clean slate,
+	 * which matters when multiple test sessions share one JVM and/or different
+	 * {@code @TestProfile}s demand different schemas.
 	 */
 	@Override
 	public void destroy() {
 		InsistenceLayerFactory.clear();
+		DeferredEnvironmentCoordinator.reset();
 	}
 
 }

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestQuarkusPlugin.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestQuarkusPlugin.java
@@ -62,9 +62,14 @@ import org.slf4j.LoggerFactory;
  * quarkus.datasource.jdbc.max-size=1
  * quarkus.datasource.jdbc.initial-size=1
  *
- * # Classloading: share the Insistence Layer registry across classloaders
+ * # Classloading: every Simulatest jar carrying cross-classloader static
+ * # state or identity-sensitive types (Environment, annotations) must be
+ * # loaded by the parent classloader, so the engine and the Arc-loaded
+ * # extension share one view of them.
  * quarkus.class-loading.parent-first-artifacts=\
  *     org.simulatest:simulatest-insistencelayer,\
+ *     org.simulatest:simulatest-environment-core,\
+ *     org.simulatest:simulatest-environment-junit-platform,\
  *     org.simulatest:simulatest-di-quarkus
  *
  * # Disable Dev Services so they don't spin up their own datasource
@@ -88,6 +93,11 @@ public final class SimulatestQuarkusPlugin implements SimulatestPlugin {
 
 	@Override
 	public void initialize(Collection<Class<?>> testClasses) {
+		// A previous test session in the same JVM may have exited abruptly
+		// and left coordinator state behind. Resetting on every session entry
+		// guarantees a clean slate regardless of how the prior one ended.
+		DeferredEnvironmentCoordinator.reset();
+
 		if (InsistenceLayerFactory.isConfigured()) {
 			logger.info("InsistenceLayer already configured; skipping bootstrap");
 			return;
@@ -168,7 +178,7 @@ public final class SimulatestQuarkusPlugin implements SimulatestPlugin {
 	 */
 	@Override
 	public EnvironmentLifecycle environmentLifecycle() {
-		return new DeferredEnvironmentLifecycle();
+		return DeferredEnvironmentLifecycle.INSTANCE;
 	}
 
 	/**

--- a/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestQuarkusPlugin.java
+++ b/simulatest-di-quarkus/src/main/java/org/simulatest/di/quarkus/SimulatestQuarkusPlugin.java
@@ -190,6 +190,7 @@ public final class SimulatestQuarkusPlugin implements SimulatestPlugin {
 	public void destroy() {
 		InsistenceLayerFactory.clear();
 		DeferredEnvironmentCoordinator.reset();
+		QuarkusEnvironmentJupiterExtension.forgetLastKnownContainer();
 	}
 
 }

--- a/simulatest-di-quarkus/src/main/resources/META-INF/native-image/org.simulatest/simulatest-di-quarkus/native-image.properties
+++ b/simulatest-di-quarkus/src/main/resources/META-INF/native-image/org.simulatest/simulatest-di-quarkus/native-image.properties
@@ -1,0 +1,14 @@
+# GraalVM native-image configuration for simulatest-di-quarkus.
+#
+# InsistenceLayerFactory holds a mutable static registry that must be
+# initialized at runtime, not at build time: build-time initialization would
+# snapshot an empty registry into the image, and the plugin's attempt to
+# configure the registry on startup would have no observable effect.
+#
+# SimulatestInsistenceDriver registers itself with DriverManager in a static
+# initializer. That registration must also happen at runtime so the driver
+# is present on the live DriverManager instance, not a build-time snapshot.
+Args = --initialize-at-run-time=\
+  org.simulatest.insistencelayer.InsistenceLayerFactory,\
+  org.simulatest.insistencelayer.InsistenceLayerRegistry,\
+  org.simulatest.di.quarkus.SimulatestInsistenceDriver

--- a/simulatest-di-quarkus/src/main/resources/META-INF/services/java.sql.Driver
+++ b/simulatest-di-quarkus/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+org.simulatest.di.quarkus.SimulatestInsistenceDriver

--- a/simulatest-di-quarkus/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/simulatest-di-quarkus/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.simulatest.di.quarkus.QuarkusEnvironmentJupiterExtension

--- a/simulatest-di-quarkus/src/main/resources/META-INF/services/org.simulatest.environment.plugin.SimulatestPlugin
+++ b/simulatest-di-quarkus/src/main/resources/META-INF/services/org.simulatest.environment.plugin.SimulatestPlugin
@@ -1,0 +1,1 @@
+org.simulatest.di.quarkus.SimulatestQuarkusPlugin

--- a/simulatest-di-quarkus/src/test/java/org/simulatest/di/quarkus/SimulatestQuarkusPluginTest.java
+++ b/simulatest-di-quarkus/src/test/java/org/simulatest/di/quarkus/SimulatestQuarkusPluginTest.java
@@ -12,6 +12,10 @@ import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.simulatest.environment.Environment;
+import org.simulatest.environment.junit5.DeferredEnvironmentCoordinator;
+import org.simulatest.environment.junit5.DeferredEnvironmentLifecycle;
+import org.simulatest.environment.plugin.EnvironmentLifecycle;
 import org.simulatest.insistencelayer.InsistenceLayer;
 import org.simulatest.insistencelayer.InsistenceLayerFactory;
 import org.simulatest.insistencelayer.infra.sql.InsistenceLayerDataSource;
@@ -106,6 +110,29 @@ class SimulatestQuarkusPluginTest {
 
 		assertFalse(InsistenceLayerFactory.isConfigured(),
 			"destroy() must clear the registry so a second run can reconfigure cleanly");
+	}
+
+	@Test
+	void pluginContributesDeferredLifecycle() {
+		EnvironmentLifecycle lifecycle = new SimulatestQuarkusPlugin().environmentLifecycle();
+
+		assertInstanceOf(DeferredEnvironmentLifecycle.class, lifecycle,
+			"Quarkus plugin must defer env execution so Arc is up when envs run");
+	}
+
+	@Test
+	void destroyAlsoClearsCoordinatorStateSoARestartStartsFresh() {
+		DeferredEnvironmentCoordinator.claimNotYetRun(FakeEnv.class);
+
+		new SimulatestQuarkusPlugin().destroy();
+
+		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(FakeEnv.class),
+			"destroy() must clear coordinator state, otherwise a second suite in the same "
+			+ "JVM would skip environments that look like they already ran");
+	}
+
+	static class FakeEnv implements Environment {
+		@Override public void run() {}
 	}
 
 	@Test

--- a/simulatest-di-quarkus/src/test/java/org/simulatest/di/quarkus/SimulatestQuarkusPluginTest.java
+++ b/simulatest-di-quarkus/src/test/java/org/simulatest/di/quarkus/SimulatestQuarkusPluginTest.java
@@ -156,15 +156,19 @@ class SimulatestQuarkusPluginTest {
 	}
 
 	@Test
-	void validationRejectsMultipleConfigurers() {
+	void validationRejectsMultipleConfigurersAndNamesBoth() {
 		QuarkusSimulatestConfigurer a = new TestConfigurer();
 		QuarkusSimulatestConfigurer b = new TestConfigurer();
 
 		IllegalStateException e = assertThrows(IllegalStateException.class,
 			() -> SimulatestQuarkusPlugin.requireExactlyOneConfigurer(List.of(a, b)));
 
-		assertTrue(e.getMessage().contains("Multiple"),
-			"error message should name both implementations: " + e.getMessage());
+		String msg = e.getMessage();
+		assertTrue(msg.contains("Multiple"), "error should flag the plurality: " + msg);
+		assertTrue(msg.contains(a.getClass().getName()),
+			"error should name the first implementation: " + msg);
+		assertTrue(msg.contains(b.getClass().getName()),
+			"error should name the second implementation: " + msg);
 	}
 
 	@Test

--- a/simulatest-di-quarkus/src/test/java/org/simulatest/di/quarkus/SimulatestQuarkusPluginTest.java
+++ b/simulatest-di-quarkus/src/test/java/org/simulatest/di/quarkus/SimulatestQuarkusPluginTest.java
@@ -1,0 +1,280 @@
+package org.simulatest.di.quarkus;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.simulatest.insistencelayer.InsistenceLayer;
+import org.simulatest.insistencelayer.InsistenceLayerFactory;
+import org.simulatest.insistencelayer.infra.sql.InsistenceLayerDataSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end checks for the plugin plus the driver — no Quarkus runtime, but
+ * enough coverage that the Agroal-compatible surface actually behaves.
+ *
+ * <p>A real Quarkus integration test with Panache lives in
+ * {@code simulatest-examples} where the Quarkus Maven plugin and runtime
+ * dependencies are already justified.
+ */
+class SimulatestQuarkusPluginTest {
+
+	private static final String UNDERLYING_URL = "jdbc:h2:mem:quarkus-plugin-test;DB_CLOSE_DELAY=-1";
+	private static final String SIMULATEST_URL = SimulatestInsistenceDriver.URL_PREFIX + UNDERLYING_URL;
+
+	private JdbcDataSource rawDataSource;
+
+	@BeforeEach
+	void setUp() {
+		rawDataSource = new JdbcDataSource();
+		rawDataSource.setURL(UNDERLYING_URL);
+		rawDataSource.setUser("sa");
+
+		TestConfigurer.rawDataSource = rawDataSource;
+		TestConfigurer.schemaApplied = false;
+
+		InsistenceLayerFactory.clear();
+	}
+
+	@AfterEach
+	void tearDown() throws SQLException {
+		InsistenceLayerFactory.clear();
+		try (Connection c = rawDataSource.getConnection();
+			 Statement s = c.createStatement()) {
+			s.execute("DROP ALL OBJECTS");
+		}
+	}
+
+	// =========================================================================
+	// Plugin — bootstrapping and schema application
+	// =========================================================================
+
+	@Test
+	void pluginConfiguresInsistenceLayerFromTheConfigurer() {
+		new SimulatestQuarkusPlugin().initialize(List.of());
+
+		assertTrue(InsistenceLayerFactory.isConfigured());
+		assertInstanceOf(InsistenceLayerDataSource.class, InsistenceLayerFactory.requireDataSource());
+	}
+
+	@Test
+	void pluginAppliesUserSuppliedSchemaBeforeAnyEnvironmentRuns() {
+		new SimulatestQuarkusPlugin().initialize(List.of());
+		assertTrue(TestConfigurer.schemaApplied);
+
+		DataSource wrapped = InsistenceLayerFactory.requireDataSource();
+		try (Connection c = wrapped.getConnection();
+			 Statement s = c.createStatement()) {
+			s.execute("INSERT INTO book (id, title) VALUES (1, 'Setup')");
+			assertEquals(1, countRows(wrapped, "SELECT COUNT(*) FROM book"));
+		} catch (SQLException e) {
+			throw new AssertionError("expected schema to be applied", e);
+		}
+	}
+
+	@Test
+	void pluginIsIdempotentWhenInsistenceLayerAlreadyConfigured() {
+		InsistenceLayerFactory.configure(rawDataSource);
+		DataSource before = InsistenceLayerFactory.requireDataSource();
+
+		new SimulatestQuarkusPlugin().initialize(List.of());
+
+		assertEquals(before, InsistenceLayerFactory.requireDataSource());
+	}
+
+	@Test
+	void destroyClearsRegistrySoNextRunStartsFresh() {
+		new SimulatestQuarkusPlugin().initialize(List.of());
+		assertTrue(InsistenceLayerFactory.isConfigured());
+
+		new SimulatestQuarkusPlugin().destroy();
+
+		assertFalse(InsistenceLayerFactory.isConfigured(),
+			"destroy() must clear the registry so a second run can reconfigure cleanly");
+	}
+
+	@Test
+	void validationRejectsZeroConfigurers() {
+		IllegalStateException e = assertThrows(IllegalStateException.class,
+			() -> SimulatestQuarkusPlugin.requireExactlyOneConfigurer(List.of()));
+
+		assertTrue(e.getMessage().contains("META-INF/services"),
+			"error message should direct the user at the service registration: " + e.getMessage());
+	}
+
+	@Test
+	void validationRejectsMultipleConfigurers() {
+		QuarkusSimulatestConfigurer a = new TestConfigurer();
+		QuarkusSimulatestConfigurer b = new TestConfigurer();
+
+		IllegalStateException e = assertThrows(IllegalStateException.class,
+			() -> SimulatestQuarkusPlugin.requireExactlyOneConfigurer(List.of(a, b)));
+
+		assertTrue(e.getMessage().contains("Multiple"),
+			"error message should name both implementations: " + e.getMessage());
+	}
+
+	@Test
+	void validationReturnsTheSoleConfigurerOtherwise() {
+		QuarkusSimulatestConfigurer only = new TestConfigurer();
+
+		QuarkusSimulatestConfigurer returned =
+			SimulatestQuarkusPlugin.requireExactlyOneConfigurer(List.of(only));
+
+		assertEquals(only, returned);
+	}
+
+	// =========================================================================
+	// Driver — URL recognition, registration, and routing
+	// =========================================================================
+
+	@Test
+	void driverAcceptsSimulatestUrls() {
+		SimulatestInsistenceDriver driver = new SimulatestInsistenceDriver();
+		assertTrue(driver.acceptsURL(SIMULATEST_URL));
+		assertTrue(driver.acceptsURL("jdbc:simulatest:jdbc:postgresql://host/db"));
+	}
+
+	@Test
+	void driverRejectsOtherUrls() {
+		SimulatestInsistenceDriver driver = new SimulatestInsistenceDriver();
+		assertFalse(driver.acceptsURL("jdbc:h2:mem:test"));
+		assertFalse(driver.acceptsURL("jdbc:postgresql://host/db"));
+		assertFalse(driver.acceptsURL(null));
+	}
+
+	@Test
+	void driverConnectReturnsNullForNonSimulatestUrl() throws SQLException {
+		assertNull(new SimulatestInsistenceDriver().connect("jdbc:h2:mem:x", null));
+	}
+
+	@Test
+	void driverManagerResolvesSimulatestUrlToOurDriver() throws SQLException {
+		new SimulatestQuarkusPlugin().initialize(List.of());
+
+		try (Connection conn = DriverManager.getConnection(SIMULATEST_URL)) {
+			assertNotNull(conn);
+
+			try (Statement stmt = conn.createStatement()) {
+				stmt.execute("INSERT INTO book (id, title) VALUES (7, 'Driver-loaded')");
+			}
+
+			assertEquals(1, countRows(InsistenceLayerFactory.requireDataSource(),
+				"SELECT COUNT(*) FROM book WHERE id = 7"));
+		}
+	}
+
+	@Test
+	void driverLazilyConfiguresInsistenceLayerWhenPluginDidNotRun() throws SQLException {
+		// Plugin intentionally NOT invoked. We still need the schema to exist for
+		// the following INSERT, so create it directly on the underlying connection.
+		try (Connection c = rawDataSource.getConnection();
+			 Statement s = c.createStatement()) {
+			s.execute("CREATE TABLE IF NOT EXISTS book (id BIGINT PRIMARY KEY, title VARCHAR(200))");
+		}
+
+		assertFalse(InsistenceLayerFactory.isConfigured());
+
+		// Credentials passed explicitly — DriverManager.getConnection(url) alone
+		// relies on the URL carrying them, which not every underlying driver supports.
+		try (Connection conn = DriverManager.getConnection(SIMULATEST_URL, "sa", "");
+			 Statement s = conn.createStatement()) {
+			s.execute("INSERT INTO book (id, title) VALUES (9, 'Lazy')");
+		}
+
+		assertTrue(InsistenceLayerFactory.isConfigured(),
+			"driver must auto-configure the Insistence Layer when invoked cold");
+	}
+
+	@Test
+	void savepointRollbackWorksThroughTheDriver() throws SQLException {
+		new SimulatestQuarkusPlugin().initialize(List.of());
+
+		InsistenceLayer layer = InsistenceLayerFactory.resolve().orElseThrow();
+
+		layer.increaseLevel();
+		try (Connection c = DriverManager.getConnection(SIMULATEST_URL);
+			 Statement s = c.createStatement()) {
+			s.execute("INSERT INTO book (id, title) VALUES (42, 'Temporary')");
+		}
+		assertEquals(1, countRows(InsistenceLayerFactory.requireDataSource(),
+			"SELECT COUNT(*) FROM book WHERE id = 42"));
+
+		layer.decreaseLevel();
+
+		assertEquals(0, countRows(InsistenceLayerFactory.requireDataSource(),
+			"SELECT COUNT(*) FROM book WHERE id = 42"),
+			"savepoint rollback must undo work done through the driver too");
+	}
+
+	@Test
+	void pluginAndDriverShareSameConnection() throws SQLException {
+		new SimulatestQuarkusPlugin().initialize(List.of());
+
+		try (Connection viaPlugin = InsistenceLayerFactory.requireDataSource().getConnection();
+			 Connection viaDriver = DriverManager.getConnection(SIMULATEST_URL)) {
+
+			try (Statement s = viaPlugin.createStatement()) {
+				s.execute("INSERT INTO book (id, title) VALUES (1, 'Plugin')");
+			}
+
+			try (Statement s = viaDriver.createStatement();
+				 var rs = s.executeQuery("SELECT title FROM book WHERE id = 1")) {
+				assertTrue(rs.next());
+				assertEquals("Plugin", rs.getString(1),
+					"driver-side Connection must see data written through plugin-side Connection");
+			}
+		}
+	}
+
+	// =========================================================================
+	// Helpers and test fixtures
+	// =========================================================================
+
+	private static int countRows(DataSource ds, String sql) throws SQLException {
+		try (Connection c = ds.getConnection();
+			 Statement s = c.createStatement();
+			 var rs = s.executeQuery(sql)) {
+			rs.next();
+			return rs.getInt(1);
+		}
+	}
+
+	public static final class TestConfigurer implements QuarkusSimulatestConfigurer {
+
+		static DataSource rawDataSource;
+		static boolean schemaApplied;
+
+		@Override
+		public DataSource dataSource() {
+			return rawDataSource;
+		}
+
+		@Override
+		public void applySchema(DataSource wrapped) {
+			try (Connection c = wrapped.getConnection();
+				 Statement s = c.createStatement()) {
+				s.execute("CREATE TABLE IF NOT EXISTS book (id BIGINT PRIMARY KEY, title VARCHAR(200))");
+				schemaApplied = true;
+			} catch (SQLException e) {
+				throw new IllegalStateException("failed to apply schema", e);
+			}
+		}
+	}
+
+}

--- a/simulatest-di-quarkus/src/test/java/org/simulatest/di/quarkus/SimulatestQuarkusPluginTest.java
+++ b/simulatest-di-quarkus/src/test/java/org/simulatest/di/quarkus/SimulatestQuarkusPluginTest.java
@@ -131,6 +131,17 @@ class SimulatestQuarkusPluginTest {
 			+ "JVM would skip environments that look like they already ran");
 	}
 
+	@Test
+	void initializeAlsoClearsCoordinatorSoADirtyPriorSessionDoesNotLeak() {
+		DeferredEnvironmentCoordinator.claimNotYetRun(FakeEnv.class);
+
+		new SimulatestQuarkusPlugin().initialize(List.of());
+
+		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(FakeEnv.class),
+			"initialize() must clear coordinator state so a session that exited abruptly "
+			+ "doesn't taint the next one");
+	}
+
 	static class FakeEnv implements Environment {
 		@Override public void run() {}
 	}

--- a/simulatest-di-quarkus/src/test/resources/META-INF/services/org.simulatest.di.quarkus.QuarkusSimulatestConfigurer
+++ b/simulatest-di-quarkus/src/test/resources/META-INF/services/org.simulatest.di.quarkus.QuarkusSimulatestConfigurer
@@ -1,0 +1,1 @@
+org.simulatest.di.quarkus.SimulatestQuarkusPluginTest$TestConfigurer

--- a/simulatest-environment-core/src/main/java/org/simulatest/environment/plugin/EagerEnvironmentLifecycle.java
+++ b/simulatest-environment-core/src/main/java/org/simulatest/environment/plugin/EagerEnvironmentLifecycle.java
@@ -10,6 +10,9 @@ import org.simulatest.environment.EnvironmentDefinition;
  */
 public final class EagerEnvironmentLifecycle implements EnvironmentLifecycle {
 
+	/** Stateless singleton; callers should prefer this over {@code new}. */
+	public static final EagerEnvironmentLifecycle INSTANCE = new EagerEnvironmentLifecycle();
+
 	@Override
 	public void onEnter(EnvironmentDefinition definition, EnvironmentExecution execution) {
 		execution.runEnvironment(definition);

--- a/simulatest-environment-core/src/main/java/org/simulatest/environment/plugin/EagerEnvironmentLifecycle.java
+++ b/simulatest-environment-core/src/main/java/org/simulatest/environment/plugin/EagerEnvironmentLifecycle.java
@@ -1,0 +1,24 @@
+package org.simulatest.environment.plugin;
+
+import org.simulatest.environment.EnvironmentDefinition;
+
+/**
+ * Default {@link EnvironmentLifecycle}: runs the environment and pushes a
+ * savepoint on entry, pops the savepoint on exit. Matches the classic tree-walk
+ * behavior the Simulatest engine has always had, and is used when no plugin
+ * contributes a different lifecycle.
+ */
+public final class EagerEnvironmentLifecycle implements EnvironmentLifecycle {
+
+	@Override
+	public void onEnter(EnvironmentDefinition definition, EnvironmentExecution execution) {
+		execution.runEnvironment(definition);
+		execution.increaseInsistenceLevel();
+	}
+
+	@Override
+	public void onExit(EnvironmentDefinition definition, EnvironmentExecution execution) {
+		execution.decreaseInsistenceLevel();
+	}
+
+}

--- a/simulatest-environment-core/src/main/java/org/simulatest/environment/plugin/EnvironmentExecution.java
+++ b/simulatest-environment-core/src/main/java/org/simulatest/environment/plugin/EnvironmentExecution.java
@@ -1,0 +1,22 @@
+package org.simulatest.environment.plugin;
+
+import org.simulatest.environment.EnvironmentDefinition;
+
+/**
+ * Narrow callback surface exposed to an {@link EnvironmentLifecycle} during
+ * the engine's tree walk. Lifecycles implementing the interface depend only
+ * on this surface, not on the wider JUnit engine, which keeps them portable
+ * between the JUnit 4 and JUnit Platform engines.
+ */
+public interface EnvironmentExecution {
+
+	/** Instantiate and run the environment via the configured factory. */
+	void runEnvironment(EnvironmentDefinition definition);
+
+	/** Push a new Insistence Layer level (creates a savepoint). */
+	void increaseInsistenceLevel();
+
+	/** Pop the current Insistence Layer level (rolls back to its savepoint). */
+	void decreaseInsistenceLevel();
+
+}

--- a/simulatest-environment-core/src/main/java/org/simulatest/environment/plugin/EnvironmentLifecycle.java
+++ b/simulatest-environment-core/src/main/java/org/simulatest/environment/plugin/EnvironmentLifecycle.java
@@ -1,0 +1,28 @@
+package org.simulatest.environment.plugin;
+
+import org.simulatest.environment.EnvironmentDefinition;
+
+/**
+ * Strategy that decides what the Simulatest engine does as it enters and exits
+ * each node of the environment tree.
+ *
+ * <p>The default, {@link EagerEnvironmentLifecycle}, runs the environment and
+ * pushes an Insistence Layer level on entry, pops the level on exit. Plugins
+ * whose DI containers are not yet available when the tree walks (Quarkus,
+ * for instance) return a different lifecycle whose {@link #onEnter} is a
+ * no-op and whose level push is done later from inside the inner test
+ * session.
+ *
+ * <p>Implementations receive an {@link EnvironmentExecution} callback object
+ * that exposes the small slice of engine functionality they need, keeping
+ * lifecycles free of any junit-platform coupling.
+ */
+public interface EnvironmentLifecycle {
+
+	/** Invoked when the engine enters {@code definition}'s subtree. */
+	void onEnter(EnvironmentDefinition definition, EnvironmentExecution execution);
+
+	/** Invoked when the engine exits {@code definition}'s subtree. */
+	void onExit(EnvironmentDefinition definition, EnvironmentExecution execution);
+
+}

--- a/simulatest-environment-core/src/main/java/org/simulatest/environment/plugin/SimulatestPlugin.java
+++ b/simulatest-environment-core/src/main/java/org/simulatest/environment/plugin/SimulatestPlugin.java
@@ -64,4 +64,22 @@ public interface SimulatestPlugin {
 	default void postProcessTestInstance(Object instance) {
 	}
 
+	/**
+	 * Returns this plugin's {@link EnvironmentLifecycle}, which decides what
+	 * happens when the Simulatest engine enters and exits an environment node
+	 * in the test tree. Return {@code null} (the default) to use whichever
+	 * lifecycle another plugin contributes, falling back to the eager tree-walk
+	 * behavior if none is contributed.
+	 *
+	 * <p>Plugins backed by DI containers that are only available once a test
+	 * class enters its JUnit lifecycle (e.g., Quarkus's Arc, bootstrapped by
+	 * {@code QuarkusTestExtension#beforeAll}) return a deferred lifecycle so
+	 * environment instantiation happens inside the inner Jupiter session.
+	 *
+	 * @return this plugin's lifecycle, or {@code null} to not contribute one
+	 */
+	default EnvironmentLifecycle environmentLifecycle() {
+		return null;
+	}
+
 }

--- a/simulatest-environment-core/src/test/java/org/simulatest/environment/plugin/EagerEnvironmentLifecycleTest.java
+++ b/simulatest-environment-core/src/test/java/org/simulatest/environment/plugin/EagerEnvironmentLifecycleTest.java
@@ -17,7 +17,7 @@ public class EagerEnvironmentLifecycleTest {
 		RecordingExecution execution = new RecordingExecution();
 		EnvironmentDefinition definition = EnvironmentDefinition.create(Fake.class);
 
-		new EagerEnvironmentLifecycle().onEnter(definition, execution);
+		EagerEnvironmentLifecycle.INSTANCE.onEnter(definition, execution);
 
 		// Eager lifecycle must run env BEFORE pushing the level so test savepoints
 		// only roll back test mutations, not the env's seed writes.
@@ -29,7 +29,7 @@ public class EagerEnvironmentLifecycleTest {
 		RecordingExecution execution = new RecordingExecution();
 		EnvironmentDefinition definition = EnvironmentDefinition.create(Fake.class);
 
-		new EagerEnvironmentLifecycle().onExit(definition, execution);
+		EagerEnvironmentLifecycle.INSTANCE.onExit(definition, execution);
 
 		assertEquals(Arrays.asList("pop"), execution.events);
 	}

--- a/simulatest-environment-core/src/test/java/org/simulatest/environment/plugin/EagerEnvironmentLifecycleTest.java
+++ b/simulatest-environment-core/src/test/java/org/simulatest/environment/plugin/EagerEnvironmentLifecycleTest.java
@@ -1,0 +1,49 @@
+package org.simulatest.environment.plugin;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.simulatest.environment.Environment;
+import org.simulatest.environment.EnvironmentDefinition;
+
+import static org.junit.Assert.assertEquals;
+
+public class EagerEnvironmentLifecycleTest {
+
+	@Test
+	public void onEnterRunsEnvironmentThenPushesLevel() {
+		RecordingExecution execution = new RecordingExecution();
+		EnvironmentDefinition definition = EnvironmentDefinition.create(Fake.class);
+
+		new EagerEnvironmentLifecycle().onEnter(definition, execution);
+
+		// Eager lifecycle must run env BEFORE pushing the level so test savepoints
+		// only roll back test mutations, not the env's seed writes.
+		assertEquals(Arrays.asList("run:Fake", "push"), execution.events);
+	}
+
+	@Test
+	public void onExitPopsLevel() {
+		RecordingExecution execution = new RecordingExecution();
+		EnvironmentDefinition definition = EnvironmentDefinition.create(Fake.class);
+
+		new EagerEnvironmentLifecycle().onExit(definition, execution);
+
+		assertEquals(Arrays.asList("pop"), execution.events);
+	}
+
+	public static class Fake implements Environment {
+		@Override public void run() {}
+	}
+
+	static final class RecordingExecution implements EnvironmentExecution {
+		final List<String> events = new ArrayList<>();
+
+		@Override public void runEnvironment(EnvironmentDefinition d) { events.add("run:" + d.getName()); }
+		@Override public void increaseInsistenceLevel() { events.add("push"); }
+		@Override public void decreaseInsistenceLevel() { events.add("pop"); }
+	}
+
+}

--- a/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinator.java
+++ b/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinator.java
@@ -22,13 +22,21 @@ import org.simulatest.environment.annotation.UseEnvironment;
  * classes, shared state is needed so each environment runs exactly once and
  * later test classes don't re-seed state their ancestors already produced.
  *
+ * <p>Tracks two independent sets: environments that have been <i>claimed</i>
+ * (first-time-seen gate) and environments whose savepoint push <i>succeeded</i>.
+ * The lifecycle's {@code onExit} reads the second set so it pops only when a
+ * push was actually recorded; a claim that never led to a push (environment
+ * threw, push threw, a Quarkus restart wiped state, etc.) does not trigger a
+ * spurious pop.
+ *
  * <p>Suite-wide static state is acceptable here because Simulatest is
  * single-threaded: the Insistence Layer's single shared connection already
  * enforces that constraint upstream.
  */
 public final class DeferredEnvironmentCoordinator {
 
-	private static final Set<Class<? extends Environment>> runEnvironments = new LinkedHashSet<>();
+	private static final Set<Class<? extends Environment>> claimed = new LinkedHashSet<>();
+	private static final Set<Class<? extends Environment>> pushed = new LinkedHashSet<>();
 
 	private DeferredEnvironmentCoordinator() {
 	}
@@ -46,13 +54,25 @@ public final class DeferredEnvironmentCoordinator {
 	public static List<Class<? extends Environment>> ancestryOf(Class<?> testClass) {
 		UseEnvironment use = resolveUseEnvironment(testClass);
 		if (use == null) return List.of();
+		return walkParentChain(use.value());
+	}
 
+	/**
+	 * Walks the {@code @EnvironmentParent} chain starting at {@code leaf},
+	 * returning the chain root-first. Throws {@link IllegalStateException} if
+	 * the chain is cyclic.
+	 *
+	 * <p>Package-private so tests can exercise cycle detection directly
+	 * without needing a {@code @UseEnvironment}-annotated fixture, which the
+	 * engine's classpath scanner would otherwise try to include in its tree.
+	 */
+	static List<Class<? extends Environment>> walkParentChain(Class<? extends Environment> leaf) {
 		List<Class<? extends Environment>> leafFirst = new ArrayList<>();
 		Set<Class<? extends Environment>> visited = new LinkedHashSet<>();
-		for (Class<? extends Environment> current = use.value(); current != null; current = parentOf(current)) {
+		for (Class<? extends Environment> current = leaf; current != null; current = parentOf(current)) {
 			if (!visited.add(current)) {
 				throw new IllegalStateException(
-					"Cyclic @EnvironmentParent chain detected starting at " + use.value().getName()
+					"Cyclic @EnvironmentParent chain detected starting at " + leaf.getName()
 					+ ": " + visited);
 			}
 			leafFirst.add(current);
@@ -62,23 +82,42 @@ public final class DeferredEnvironmentCoordinator {
 	}
 
 	/**
-	 * Marks {@code env} as already run in the current suite, so subsequent
-	 * callers receive {@code false} from {@link #claimNotYetRun(Class)}.
+	 * Marks {@code env} as already claimed in the current suite, so subsequent
+	 * callers receive {@code false}.
 	 *
 	 * @return {@code true} if this call registered the environment; {@code false}
 	 *         if another caller already did.
 	 */
 	public static synchronized boolean claimNotYetRun(Class<? extends Environment> env) {
-		return runEnvironments.add(env);
+		return claimed.add(env);
 	}
 
 	/**
-	 * Clears tracking for {@code env}. Called by the engine when the tree walk
-	 * exits the environment's subtree — at that point the savepoint has been
-	 * popped and the environment will need to run again if somehow re-entered.
+	 * Records that {@code env} successfully had its Insistence Layer level
+	 * pushed, so the matching {@code onExit} knows it's safe to pop.
+	 */
+	public static synchronized void recordPush(Class<? extends Environment> env) {
+		pushed.add(env);
+	}
+
+	/**
+	 * Returns whether {@code env}'s level was recorded as pushed. The lifecycle
+	 * uses this to decide whether to pop on exit; a claim without a recorded
+	 * push means the push never happened (failure, restart, etc.) and no pop
+	 * should occur.
+	 */
+	public static synchronized boolean wasPushed(Class<? extends Environment> env) {
+		return pushed.contains(env);
+	}
+
+	/**
+	 * Clears tracking for {@code env}. Called by the lifecycle when the tree
+	 * walk exits the environment's subtree: the savepoint has been popped and
+	 * the environment will need to run again if somehow re-entered.
 	 */
 	public static synchronized void forget(Class<? extends Environment> env) {
-		runEnvironments.remove(env);
+		claimed.remove(env);
+		pushed.remove(env);
 	}
 
 	/**
@@ -88,7 +127,8 @@ public final class DeferredEnvironmentCoordinator {
 	 * database.
 	 */
 	public static synchronized void reset() {
-		runEnvironments.clear();
+		claimed.clear();
+		pushed.clear();
 	}
 
 	private static UseEnvironment resolveUseEnvironment(Class<?> testClass) {

--- a/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinator.java
+++ b/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinator.java
@@ -1,0 +1,86 @@
+package org.simulatest.environment.junit5;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.simulatest.environment.Environment;
+import org.simulatest.environment.annotation.EnvironmentParent;
+import org.simulatest.environment.annotation.UseEnvironment;
+
+/**
+ * Cross-class coordination for deferred environment execution.
+ *
+ * <p>When a plugin contributes a {@link DeferredEnvironmentLifecycle} via
+ * {@link org.simulatest.environment.plugin.SimulatestPlugin#environmentLifecycle()},
+ * the Simulatest engine skips running environments in its tree walk. A
+ * Jupiter extension shipped by the plugin then runs them from inside the
+ * inner Jupiter session, after its DI container is ready. Since the inner
+ * session is constructed per test class but the environment tree spans many
+ * classes, shared state is needed so each environment runs exactly once and
+ * later test classes don't re-seed state their ancestors already produced.
+ *
+ * <p>Suite-wide static state is acceptable here because Simulatest is
+ * single-threaded: the Insistence Layer's single shared connection already
+ * enforces that constraint upstream.
+ */
+public final class DeferredEnvironmentCoordinator {
+
+	private static final Set<Class<? extends Environment>> runEnvironments = new LinkedHashSet<>();
+
+	private DeferredEnvironmentCoordinator() {
+	}
+
+	/**
+	 * Returns the environment ancestry for {@code testClass} root-first: the
+	 * outermost ancestor is first, the class's own {@link UseEnvironment} last.
+	 * Returns an empty list if the class has no {@code @UseEnvironment}.
+	 */
+	public static List<Class<? extends Environment>> ancestryOf(Class<?> testClass) {
+		UseEnvironment use = testClass.getAnnotation(UseEnvironment.class);
+		if (use == null) return List.of();
+
+		List<Class<? extends Environment>> leafFirst = new ArrayList<>();
+		for (Class<? extends Environment> current = use.value(); current != null; current = parentOf(current)) {
+			leafFirst.add(current);
+		}
+		Collections.reverse(leafFirst);
+		return leafFirst;
+	}
+
+	/**
+	 * Marks {@code env} as already run in the current suite, so subsequent
+	 * callers receive {@code false} from {@link #claimNotYetRun(Class)}.
+	 *
+	 * @return {@code true} if this call registered the environment; {@code false}
+	 *         if another caller already did.
+	 */
+	public static synchronized boolean claimNotYetRun(Class<? extends Environment> env) {
+		return runEnvironments.add(env);
+	}
+
+	/**
+	 * Clears tracking for {@code env}. Called by the engine when the tree walk
+	 * exits the environment's subtree — at that point the savepoint has been
+	 * popped and the environment will need to run again if somehow re-entered.
+	 */
+	public static synchronized void forget(Class<? extends Environment> env) {
+		runEnvironments.remove(env);
+	}
+
+	/**
+	 * Resets all tracking. Called by the engine between test sessions so the
+	 * next suite starts clean.
+	 */
+	public static synchronized void reset() {
+		runEnvironments.clear();
+	}
+
+	private static Class<? extends Environment> parentOf(Class<? extends Environment> env) {
+		EnvironmentParent annotation = env.getAnnotation(EnvironmentParent.class);
+		return annotation != null ? annotation.value() : null;
+	}
+
+}

--- a/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinator.java
+++ b/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinator.java
@@ -91,14 +91,10 @@ public final class DeferredEnvironmentCoordinator {
 		runEnvironments.clear();
 	}
 
-	// Walks @Nested enclosing chain so an inner class inherits the outer
-	// class's @UseEnvironment rather than coming back empty.
 	private static UseEnvironment resolveUseEnvironment(Class<?> testClass) {
-		for (Class<?> current = testClass; current != null; current = current.getEnclosingClass()) {
-			UseEnvironment use = current.getAnnotation(UseEnvironment.class);
-			if (use != null) return use;
-		}
-		return null;
+		return UseEnvironmentClassScanner.resolveUseEnvironmentClass(testClass)
+				.map(c -> c.getAnnotation(UseEnvironment.class))
+				.orElse(null);
 	}
 
 	private static Class<? extends Environment> parentOf(Class<? extends Environment> env) {

--- a/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinator.java
+++ b/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinator.java
@@ -35,15 +35,26 @@ public final class DeferredEnvironmentCoordinator {
 
 	/**
 	 * Returns the environment ancestry for {@code testClass} root-first: the
-	 * outermost ancestor is first, the class's own {@link UseEnvironment} last.
-	 * Returns an empty list if the class has no {@code @UseEnvironment}.
+	 * outermost ancestor is first, the class's leaf {@link UseEnvironment}
+	 * last. Returns an empty list if neither {@code testClass} nor any of its
+	 * enclosing classes carries {@code @UseEnvironment}.
+	 *
+	 * <p>Walks enclosing classes so {@code @Nested} inner classes inherit the
+	 * outer class's environment. Detects cycles in the {@link EnvironmentParent}
+	 * chain and fails loudly rather than looping.
 	 */
 	public static List<Class<? extends Environment>> ancestryOf(Class<?> testClass) {
-		UseEnvironment use = testClass.getAnnotation(UseEnvironment.class);
+		UseEnvironment use = resolveUseEnvironment(testClass);
 		if (use == null) return List.of();
 
 		List<Class<? extends Environment>> leafFirst = new ArrayList<>();
+		Set<Class<? extends Environment>> visited = new LinkedHashSet<>();
 		for (Class<? extends Environment> current = use.value(); current != null; current = parentOf(current)) {
+			if (!visited.add(current)) {
+				throw new IllegalStateException(
+					"Cyclic @EnvironmentParent chain detected starting at " + use.value().getName()
+					+ ": " + visited);
+			}
 			leafFirst.add(current);
 		}
 		Collections.reverse(leafFirst);
@@ -71,11 +82,23 @@ public final class DeferredEnvironmentCoordinator {
 	}
 
 	/**
-	 * Resets all tracking. Called by the engine between test sessions so the
-	 * next suite starts clean.
+	 * Resets all tracking. Called between test sessions so the next suite starts
+	 * clean, and when the Quarkus runtime restarts (e.g., {@code @TestProfile}
+	 * switch) so stale "already run" records don't mask the new runtime's empty
+	 * database.
 	 */
 	public static synchronized void reset() {
 		runEnvironments.clear();
+	}
+
+	// Walks @Nested enclosing chain so an inner class inherits the outer
+	// class's @UseEnvironment rather than coming back empty.
+	private static UseEnvironment resolveUseEnvironment(Class<?> testClass) {
+		for (Class<?> current = testClass; current != null; current = current.getEnclosingClass()) {
+			UseEnvironment use = current.getAnnotation(UseEnvironment.class);
+			if (use != null) return use;
+		}
+		return null;
 	}
 
 	private static Class<? extends Environment> parentOf(Class<? extends Environment> env) {

--- a/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentLifecycle.java
+++ b/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentLifecycle.java
@@ -17,6 +17,9 @@ import org.simulatest.environment.plugin.EnvironmentLifecycle;
  */
 public final class DeferredEnvironmentLifecycle implements EnvironmentLifecycle {
 
+	/** Stateless singleton; callers should prefer this over {@code new}. */
+	public static final DeferredEnvironmentLifecycle INSTANCE = new DeferredEnvironmentLifecycle();
+
 	@Override
 	public void onEnter(EnvironmentDefinition definition, EnvironmentExecution execution) {
 		// Intentionally empty. See class javadoc.

--- a/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentLifecycle.java
+++ b/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentLifecycle.java
@@ -1,0 +1,31 @@
+package org.simulatest.environment.junit5;
+
+import org.simulatest.environment.EnvironmentDefinition;
+import org.simulatest.environment.plugin.EnvironmentExecution;
+import org.simulatest.environment.plugin.EnvironmentLifecycle;
+
+/**
+ * {@link EnvironmentLifecycle} that defers environment instantiation and
+ * savepoint placement into the inner Jupiter session. The engine's
+ * tree-walk entry is a no-op; a Jupiter extension shipped by the deferring
+ * plugin runs the environment and pushes the savepoint after its DI
+ * container is ready.
+ *
+ * <p>Exit pops the savepoint the extension pushed and clears the coordinator's
+ * record for this environment, so a sibling or re-entry triggers a fresh run
+ * rather than reusing now-rolled-back state.
+ */
+public final class DeferredEnvironmentLifecycle implements EnvironmentLifecycle {
+
+	@Override
+	public void onEnter(EnvironmentDefinition definition, EnvironmentExecution execution) {
+		// Intentionally empty. See class javadoc.
+	}
+
+	@Override
+	public void onExit(EnvironmentDefinition definition, EnvironmentExecution execution) {
+		execution.decreaseInsistenceLevel();
+		DeferredEnvironmentCoordinator.forget(definition.getEnvironmentClass());
+	}
+
+}

--- a/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentLifecycle.java
+++ b/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/DeferredEnvironmentLifecycle.java
@@ -1,5 +1,6 @@
 package org.simulatest.environment.junit5;
 
+import org.simulatest.environment.Environment;
 import org.simulatest.environment.EnvironmentDefinition;
 import org.simulatest.environment.plugin.EnvironmentExecution;
 import org.simulatest.environment.plugin.EnvironmentLifecycle;
@@ -11,9 +12,11 @@ import org.simulatest.environment.plugin.EnvironmentLifecycle;
  * plugin runs the environment and pushes the savepoint after its DI
  * container is ready.
  *
- * <p>Exit pops the savepoint the extension pushed and clears the coordinator's
- * record for this environment, so a sibling or re-entry triggers a fresh run
- * rather than reusing now-rolled-back state.
+ * <p>Exit pops the savepoint only when the coordinator confirms one was
+ * actually pushed for this environment. A claim that never led to a push
+ * (the extension failed before pushing, a Quarkus restart wiped state, etc.)
+ * leaves the stack alone, which prevents popping a savepoint that doesn't
+ * exist.
  */
 public final class DeferredEnvironmentLifecycle implements EnvironmentLifecycle {
 
@@ -27,8 +30,11 @@ public final class DeferredEnvironmentLifecycle implements EnvironmentLifecycle 
 
 	@Override
 	public void onExit(EnvironmentDefinition definition, EnvironmentExecution execution) {
-		execution.decreaseInsistenceLevel();
-		DeferredEnvironmentCoordinator.forget(definition.getEnvironmentClass());
+		Class<? extends Environment> environmentClass = definition.getEnvironmentClass();
+		if (DeferredEnvironmentCoordinator.wasPushed(environmentClass)) {
+			execution.decreaseInsistenceLevel();
+		}
+		DeferredEnvironmentCoordinator.forget(environmentClass);
 	}
 
 }

--- a/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/SimulatestExecutionContext.java
+++ b/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/SimulatestExecutionContext.java
@@ -96,6 +96,9 @@ public final class SimulatestExecutionContext implements EngineExecutionContext 
 	 * lifecycles and other plugin-side collaborators. Hides engine-only state
 	 * (session, plugins list, classloader helpers) that a lifecycle has no
 	 * business seeing.
+	 *
+	 * <p>The returned instance is stable for the lifetime of this context, so
+	 * callers can safely cache the reference.
 	 */
 	public EnvironmentExecution asExecution() {
 		return execution;

--- a/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/SimulatestExecutionContext.java
+++ b/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/SimulatestExecutionContext.java
@@ -18,19 +18,20 @@ import org.simulatest.insistencelayer.InsistenceLayer;
 
 /**
  * Per-engine execution context bridging a {@link SimulatestSession} into
- * JUnit Platform's {@link EngineExecutionContext}. Implements
- * {@link EnvironmentExecution} so {@link EnvironmentLifecycle}
- * implementations receive a narrow callback surface instead of the full
- * engine state.
+ * JUnit Platform's {@link EngineExecutionContext}.
+ *
+ * <p>Exposes a narrow {@link EnvironmentExecution} view through
+ * {@link #asExecution()} for {@link EnvironmentLifecycle} implementations,
+ * keeping them free of any engine-internal surface.
  *
  * <p><b>Thread-safety:</b> the instance itself is not thread-safe — Jupiter
  * invokes lifecycle methods on a single executor thread per engine. The
  * {@link #getCurrent() current-context} ThreadLocal is per-thread by design
  * and returns empty if an extension runs on a thread that never set it.</p>
  */
-public final class SimulatestExecutionContext implements EngineExecutionContext, EnvironmentExecution {
+public final class SimulatestExecutionContext implements EngineExecutionContext {
 
-	private static final EnvironmentLifecycle DEFAULT_LIFECYCLE = new EagerEnvironmentLifecycle();
+	private static final EnvironmentLifecycle DEFAULT_LIFECYCLE = EagerEnvironmentLifecycle.INSTANCE;
 
 	static final SimulatestExecutionContext EMPTY = new SimulatestExecutionContext(null, null, null, List.of());
 
@@ -45,6 +46,7 @@ public final class SimulatestExecutionContext implements EngineExecutionContext,
 	private final InsistenceLayer insistenceLayer;
 	private final List<SimulatestPlugin> plugins;
 	private final EnvironmentLifecycle lifecycle;
+	private final EnvironmentExecution execution;
 
 	public SimulatestExecutionContext(SimulatestSession session) {
 		this(
@@ -61,6 +63,7 @@ public final class SimulatestExecutionContext implements EngineExecutionContext,
 		this.insistenceLayer = insistenceLayer;
 		this.plugins = plugins;
 		this.lifecycle = selectLifecycle(plugins);
+		this.execution = new LifecycleExecutionView();
 	}
 
 	private static EnvironmentLifecycle selectLifecycle(List<SimulatestPlugin> plugins) {
@@ -88,7 +91,16 @@ public final class SimulatestExecutionContext implements EngineExecutionContext,
 		return lifecycle;
 	}
 
-	@Override
+	/**
+	 * Narrow {@link EnvironmentExecution} view onto this context for use by
+	 * lifecycles and other plugin-side collaborators. Hides engine-only state
+	 * (session, plugins list, classloader helpers) that a lifecycle has no
+	 * business seeing.
+	 */
+	public EnvironmentExecution asExecution() {
+		return execution;
+	}
+
 	public void runEnvironment(EnvironmentDefinition definition) {
 		Objects.requireNonNull(definition, "definition must not be null");
 		EnvironmentFactory envFactory = factory().orElseThrow(() -> new IllegalStateException(
@@ -101,12 +113,10 @@ public final class SimulatestExecutionContext implements EngineExecutionContext,
 		}
 	}
 
-	@Override
 	public void increaseInsistenceLevel() {
 		ifInsistenceLayer(InsistenceLayer::increaseLevel);
 	}
 
-	@Override
 	public void decreaseInsistenceLevel() {
 		ifInsistenceLayer(InsistenceLayer::decreaseLevelOrCleanup);
 	}
@@ -142,6 +152,20 @@ public final class SimulatestExecutionContext implements EngineExecutionContext,
 			action.run();
 		} finally {
 			CURRENT.remove();
+		}
+	}
+
+	// Inner class so the context doesn't publicly implement EnvironmentExecution.
+	// Lifecycle implementations see only the three methods they need.
+	private final class LifecycleExecutionView implements EnvironmentExecution {
+		@Override public void runEnvironment(EnvironmentDefinition definition) {
+			SimulatestExecutionContext.this.runEnvironment(definition);
+		}
+		@Override public void increaseInsistenceLevel() {
+			SimulatestExecutionContext.this.increaseInsistenceLevel();
+		}
+		@Override public void decreaseInsistenceLevel() {
+			SimulatestExecutionContext.this.decreaseInsistenceLevel();
 		}
 	}
 

--- a/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/SimulatestExecutionContext.java
+++ b/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/SimulatestExecutionContext.java
@@ -9,20 +9,28 @@ import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
 import org.simulatest.environment.EnvironmentDefinition;
 import org.simulatest.environment.EnvironmentFactory;
 import org.simulatest.environment.infra.exception.EnvironmentExecutionException;
+import org.simulatest.environment.plugin.EagerEnvironmentLifecycle;
+import org.simulatest.environment.plugin.EnvironmentExecution;
+import org.simulatest.environment.plugin.EnvironmentLifecycle;
 import org.simulatest.environment.plugin.SimulatestPlugin;
 import org.simulatest.environment.SimulatestSession;
 import org.simulatest.insistencelayer.InsistenceLayer;
 
 /**
  * Per-engine execution context bridging a {@link SimulatestSession} into
- * JUnit Platform's {@link EngineExecutionContext}.
+ * JUnit Platform's {@link EngineExecutionContext}. Implements
+ * {@link EnvironmentExecution} so {@link EnvironmentLifecycle}
+ * implementations receive a narrow callback surface instead of the full
+ * engine state.
  *
  * <p><b>Thread-safety:</b> the instance itself is not thread-safe — Jupiter
  * invokes lifecycle methods on a single executor thread per engine. The
  * {@link #getCurrent() current-context} ThreadLocal is per-thread by design
  * and returns empty if an extension runs on a thread that never set it.</p>
  */
-public final class SimulatestExecutionContext implements EngineExecutionContext {
+public final class SimulatestExecutionContext implements EngineExecutionContext, EnvironmentExecution {
+
+	private static final EnvironmentLifecycle DEFAULT_LIFECYCLE = new EagerEnvironmentLifecycle();
 
 	static final SimulatestExecutionContext EMPTY = new SimulatestExecutionContext(null, null, null, List.of());
 
@@ -36,6 +44,7 @@ public final class SimulatestExecutionContext implements EngineExecutionContext 
 	private final EnvironmentFactory factory;
 	private final InsistenceLayer insistenceLayer;
 	private final List<SimulatestPlugin> plugins;
+	private final EnvironmentLifecycle lifecycle;
 
 	public SimulatestExecutionContext(SimulatestSession session) {
 		this(
@@ -51,6 +60,15 @@ public final class SimulatestExecutionContext implements EngineExecutionContext 
 		this.factory = factory;
 		this.insistenceLayer = insistenceLayer;
 		this.plugins = plugins;
+		this.lifecycle = selectLifecycle(plugins);
+	}
+
+	private static EnvironmentLifecycle selectLifecycle(List<SimulatestPlugin> plugins) {
+		return plugins.stream()
+				.map(SimulatestPlugin::environmentLifecycle)
+				.filter(Objects::nonNull)
+				.findFirst()
+				.orElse(DEFAULT_LIFECYCLE);
 	}
 
 	public Optional<InsistenceLayer> insistenceLayer() {
@@ -65,6 +83,12 @@ public final class SimulatestExecutionContext implements EngineExecutionContext 
 		return plugins;
 	}
 
+	/** The lifecycle chosen for this session. Descriptors delegate enter/exit to it. */
+	public EnvironmentLifecycle lifecycle() {
+		return lifecycle;
+	}
+
+	@Override
 	public void runEnvironment(EnvironmentDefinition definition) {
 		Objects.requireNonNull(definition, "definition must not be null");
 		EnvironmentFactory envFactory = factory().orElseThrow(() -> new IllegalStateException(
@@ -77,10 +101,12 @@ public final class SimulatestExecutionContext implements EngineExecutionContext 
 		}
 	}
 
+	@Override
 	public void increaseInsistenceLevel() {
 		ifInsistenceLayer(InsistenceLayer::increaseLevel);
 	}
 
+	@Override
 	public void decreaseInsistenceLevel() {
 		ifInsistenceLayer(InsistenceLayer::decreaseLevelOrCleanup);
 	}

--- a/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/descriptor/EnvironmentTestDescriptor.java
+++ b/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/descriptor/EnvironmentTestDescriptor.java
@@ -34,13 +34,13 @@ public final class EnvironmentTestDescriptor extends AbstractTestDescriptor
 
 	@Override
 	public SimulatestExecutionContext before(SimulatestExecutionContext context) {
-		context.lifecycle().onEnter(definition, context);
+		context.lifecycle().onEnter(definition, context.asExecution());
 		return context;
 	}
 
 	@Override
 	public void after(SimulatestExecutionContext context) {
-		context.lifecycle().onExit(definition, context);
+		context.lifecycle().onExit(definition, context.asExecution());
 
 		// Skip the redundant reset for the last sibling: the parent's decreaseLevel
 		// will roll back past this savepoint anyway, so resetting here would waste I/O.

--- a/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/descriptor/EnvironmentTestDescriptor.java
+++ b/simulatest-environment-junit-platform/src/main/java/org/simulatest/environment/junit5/descriptor/EnvironmentTestDescriptor.java
@@ -34,14 +34,13 @@ public final class EnvironmentTestDescriptor extends AbstractTestDescriptor
 
 	@Override
 	public SimulatestExecutionContext before(SimulatestExecutionContext context) {
-		context.runEnvironment(definition);
-		context.increaseInsistenceLevel();
+		context.lifecycle().onEnter(definition, context);
 		return context;
 	}
 
 	@Override
 	public void after(SimulatestExecutionContext context) {
-		context.decreaseInsistenceLevel();
+		context.lifecycle().onExit(definition, context);
 
 		// Skip the redundant reset for the last sibling: the parent's decreaseLevel
 		// will roll back past this savepoint anyway, so resetting here would waste I/O.

--- a/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinatorTest.java
+++ b/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinatorTest.java
@@ -8,8 +8,11 @@ import org.simulatest.environment.Environment;
 import org.simulatest.environment.annotation.EnvironmentParent;
 import org.simulatest.environment.annotation.UseEnvironment;
 
+import org.simulatest.environment.junit5.testdouble.CyclicEnvironmentFixtures;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DeferredEnvironmentCoordinatorTest {
@@ -43,6 +46,15 @@ class DeferredEnvironmentCoordinatorTest {
 
 		assertEquals(List.of(Root.class, Middle.class, Leaf.class), ancestry,
 			"root-first ordering lets callers push savepoints outermost-to-innermost");
+	}
+
+	@Test
+	void cyclicParentChainThrowsRatherThanLooping() {
+		IllegalStateException error = assertThrows(IllegalStateException.class,
+			() -> DeferredEnvironmentCoordinator.walkParentChain(CyclicEnvironmentFixtures.NodeA.class));
+
+		assertTrue(error.getMessage().contains("Cyclic @EnvironmentParent"),
+			"error should name the cycle condition: " + error.getMessage());
 	}
 
 	@Test
@@ -85,6 +97,33 @@ class DeferredEnvironmentCoordinatorTest {
 		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(Root.class));
 		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(Middle.class));
 		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(Leaf.class));
+	}
+
+	@Test
+	void wasPushedIsFalseUntilRecorded() {
+		DeferredEnvironmentCoordinator.claimNotYetRun(Root.class);
+
+		assertFalse(DeferredEnvironmentCoordinator.wasPushed(Root.class),
+			"a bare claim without a recorded push must not signal wasPushed");
+	}
+
+	@Test
+	void wasPushedFlipsToTrueAfterRecord() {
+		DeferredEnvironmentCoordinator.claimNotYetRun(Root.class);
+		DeferredEnvironmentCoordinator.recordPush(Root.class);
+
+		assertTrue(DeferredEnvironmentCoordinator.wasPushed(Root.class));
+	}
+
+	@Test
+	void forgetClearsBothClaimAndPush() {
+		DeferredEnvironmentCoordinator.claimNotYetRun(Root.class);
+		DeferredEnvironmentCoordinator.recordPush(Root.class);
+
+		DeferredEnvironmentCoordinator.forget(Root.class);
+
+		assertFalse(DeferredEnvironmentCoordinator.wasPushed(Root.class));
+		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(Root.class));
 	}
 
 	// =========================================================================

--- a/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinatorTest.java
+++ b/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinatorTest.java
@@ -1,0 +1,107 @@
+package org.simulatest.environment.junit5;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.simulatest.environment.Environment;
+import org.simulatest.environment.annotation.EnvironmentParent;
+import org.simulatest.environment.annotation.UseEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DeferredEnvironmentCoordinatorTest {
+
+	@BeforeEach
+	void startFresh() {
+		DeferredEnvironmentCoordinator.reset();
+	}
+
+	// =========================================================================
+	// Ancestry walking via @UseEnvironment + @EnvironmentParent
+	// =========================================================================
+
+	@Test
+	void ancestryIsEmptyWhenClassHasNoUseEnvironment() {
+		assertTrue(DeferredEnvironmentCoordinator.ancestryOf(NoAnnotation.class).isEmpty());
+	}
+
+	@Test
+	void ancestryForLeafWithoutParentIsTheLeafAlone() {
+		List<Class<? extends Environment>> ancestry =
+			DeferredEnvironmentCoordinator.ancestryOf(UsesRoot.class);
+
+		assertEquals(List.of(Root.class), ancestry);
+	}
+
+	@Test
+	void ancestryIsOrderedRootFirst() {
+		List<Class<? extends Environment>> ancestry =
+			DeferredEnvironmentCoordinator.ancestryOf(UsesLeaf.class);
+
+		assertEquals(List.of(Root.class, Middle.class, Leaf.class), ancestry,
+			"root-first ordering lets callers push savepoints outermost-to-innermost");
+	}
+
+	// =========================================================================
+	// Claim / forget / reset semantics
+	// =========================================================================
+
+	@Test
+	void firstClaimWinsSubsequentClaimsLose() {
+		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(Root.class));
+		assertFalse(DeferredEnvironmentCoordinator.claimNotYetRun(Root.class));
+		assertFalse(DeferredEnvironmentCoordinator.claimNotYetRun(Root.class));
+	}
+
+	@Test
+	void forgetAllowsReclaim() {
+		DeferredEnvironmentCoordinator.claimNotYetRun(Root.class);
+		DeferredEnvironmentCoordinator.forget(Root.class);
+
+		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(Root.class),
+			"after exit, a re-entered subtree must be able to claim again");
+	}
+
+	@Test
+	void resetClearsEverything() {
+		DeferredEnvironmentCoordinator.claimNotYetRun(Root.class);
+		DeferredEnvironmentCoordinator.claimNotYetRun(Middle.class);
+		DeferredEnvironmentCoordinator.claimNotYetRun(Leaf.class);
+
+		DeferredEnvironmentCoordinator.reset();
+
+		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(Root.class));
+		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(Middle.class));
+		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(Leaf.class));
+	}
+
+	// =========================================================================
+	// Test fixtures
+	// =========================================================================
+
+	static class Root implements Environment {
+		@Override public void run() {}
+	}
+
+	@EnvironmentParent(Root.class)
+	static class Middle implements Environment {
+		@Override public void run() {}
+	}
+
+	@EnvironmentParent(Middle.class)
+	static class Leaf implements Environment {
+		@Override public void run() {}
+	}
+
+	static class NoAnnotation { }
+
+	@UseEnvironment(Root.class)
+	static class UsesRoot { }
+
+	@UseEnvironment(Leaf.class)
+	static class UsesLeaf { }
+
+}

--- a/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinatorTest.java
+++ b/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/DeferredEnvironmentCoordinatorTest.java
@@ -45,6 +45,15 @@ class DeferredEnvironmentCoordinatorTest {
 			"root-first ordering lets callers push savepoints outermost-to-innermost");
 	}
 
+	@Test
+	void nestedInnerClassInheritsOuterUseEnvironment() {
+		List<Class<? extends Environment>> ancestry =
+			DeferredEnvironmentCoordinator.ancestryOf(UsesLeaf.NestedInner.class);
+
+		assertEquals(List.of(Root.class, Middle.class, Leaf.class), ancestry,
+			"@Nested inner classes must pick up the outer class's environment");
+	}
+
 	// =========================================================================
 	// Claim / forget / reset semantics
 	// =========================================================================
@@ -102,6 +111,8 @@ class DeferredEnvironmentCoordinatorTest {
 	static class UsesRoot { }
 
 	@UseEnvironment(Leaf.class)
-	static class UsesLeaf { }
+	static class UsesLeaf {
+		static class NestedInner { }
+	}
 
 }

--- a/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/DeferredEnvironmentLifecycleTest.java
+++ b/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/DeferredEnvironmentLifecycleTest.java
@@ -24,7 +24,7 @@ class DeferredEnvironmentLifecycleTest {
 		RecordingExecution execution = new RecordingExecution();
 		EnvironmentDefinition definition = EnvironmentDefinition.create(Fake.class);
 
-		new DeferredEnvironmentLifecycle().onEnter(definition, execution);
+		DeferredEnvironmentLifecycle.INSTANCE.onEnter(definition, execution);
 
 		assertTrue(execution.events.isEmpty(),
 			"deferred entry must not run the env nor push a level; that work is done later "
@@ -37,7 +37,7 @@ class DeferredEnvironmentLifecycleTest {
 		RecordingExecution execution = new RecordingExecution();
 		EnvironmentDefinition definition = EnvironmentDefinition.create(Fake.class);
 
-		new DeferredEnvironmentLifecycle().onExit(definition, execution);
+		DeferredEnvironmentLifecycle.INSTANCE.onExit(definition, execution);
 
 		assertEquals(List.of("pop"), execution.events);
 		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(Fake.class),

--- a/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/DeferredEnvironmentLifecycleTest.java
+++ b/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/DeferredEnvironmentLifecycleTest.java
@@ -32,8 +32,9 @@ class DeferredEnvironmentLifecycleTest {
 	}
 
 	@Test
-	void onExitPopsLevelAndForgetsCoordinatorRecord() {
+	void onExitPopsLevelAndForgetsCoordinatorRecordWhenPushWasRecorded() {
 		DeferredEnvironmentCoordinator.claimNotYetRun(Fake.class);
+		DeferredEnvironmentCoordinator.recordPush(Fake.class);
 		RecordingExecution execution = new RecordingExecution();
 		EnvironmentDefinition definition = EnvironmentDefinition.create(Fake.class);
 
@@ -42,6 +43,18 @@ class DeferredEnvironmentLifecycleTest {
 		assertEquals(List.of("pop"), execution.events);
 		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(Fake.class),
 			"after exit, the coordinator must allow a fresh claim on the same env");
+	}
+
+	@Test
+	void onExitSkipsPopWhenNoPushWasRecorded() {
+		DeferredEnvironmentCoordinator.claimNotYetRun(Fake.class);
+		RecordingExecution execution = new RecordingExecution();
+		EnvironmentDefinition definition = EnvironmentDefinition.create(Fake.class);
+
+		DeferredEnvironmentLifecycle.INSTANCE.onExit(definition, execution);
+
+		assertTrue(execution.events.isEmpty(),
+			"onExit must not pop a savepoint that was never successfully pushed");
 	}
 
 	static class Fake implements Environment {

--- a/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/DeferredEnvironmentLifecycleTest.java
+++ b/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/DeferredEnvironmentLifecycleTest.java
@@ -1,0 +1,59 @@
+package org.simulatest.environment.junit5;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.simulatest.environment.Environment;
+import org.simulatest.environment.EnvironmentDefinition;
+import org.simulatest.environment.plugin.EnvironmentExecution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DeferredEnvironmentLifecycleTest {
+
+	@BeforeEach
+	void startFresh() {
+		DeferredEnvironmentCoordinator.reset();
+	}
+
+	@Test
+	void onEnterDoesNothingSoEngineLeavesRunAndPushToTheExtension() {
+		RecordingExecution execution = new RecordingExecution();
+		EnvironmentDefinition definition = EnvironmentDefinition.create(Fake.class);
+
+		new DeferredEnvironmentLifecycle().onEnter(definition, execution);
+
+		assertTrue(execution.events.isEmpty(),
+			"deferred entry must not run the env nor push a level; that work is done later "
+			+ "by the plugin's Jupiter extension, after its DI container is up");
+	}
+
+	@Test
+	void onExitPopsLevelAndForgetsCoordinatorRecord() {
+		DeferredEnvironmentCoordinator.claimNotYetRun(Fake.class);
+		RecordingExecution execution = new RecordingExecution();
+		EnvironmentDefinition definition = EnvironmentDefinition.create(Fake.class);
+
+		new DeferredEnvironmentLifecycle().onExit(definition, execution);
+
+		assertEquals(List.of("pop"), execution.events);
+		assertTrue(DeferredEnvironmentCoordinator.claimNotYetRun(Fake.class),
+			"after exit, the coordinator must allow a fresh claim on the same env");
+	}
+
+	static class Fake implements Environment {
+		@Override public void run() {}
+	}
+
+	static final class RecordingExecution implements EnvironmentExecution {
+		final List<String> events = new ArrayList<>();
+
+		@Override public void runEnvironment(EnvironmentDefinition d) { events.add("run:" + d.getName()); }
+		@Override public void increaseInsistenceLevel() { events.add("push"); }
+		@Override public void decreaseInsistenceLevel() { events.add("pop"); }
+	}
+
+}

--- a/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/testdouble/CyclicEnvironmentFixtures.java
+++ b/simulatest-environment-junit-platform/src/test/java/org/simulatest/environment/junit5/testdouble/CyclicEnvironmentFixtures.java
@@ -1,0 +1,27 @@
+package org.simulatest.environment.junit5.testdouble;
+
+import org.simulatest.environment.Environment;
+import org.simulatest.environment.annotation.EnvironmentParent;
+
+/**
+ * A cyclic {@code @EnvironmentParent} chain kept isolated so the main
+ * SimulatestTestEngine's classpath scan does not build a tree from it and
+ * fail suite discovery. Deliberately has no {@code @UseEnvironment} entry
+ * point: the test drives the cycle detection through
+ * {@code DeferredEnvironmentCoordinator.walkParentChain} directly.
+ */
+public final class CyclicEnvironmentFixtures {
+
+	private CyclicEnvironmentFixtures() { }
+
+	@EnvironmentParent(NodeB.class)
+	public static class NodeA implements Environment {
+		@Override public void run() { }
+	}
+
+	@EnvironmentParent(NodeA.class)
+	public static class NodeB implements Environment {
+		@Override public void run() { }
+	}
+
+}


### PR DESCRIPTION
  Adds Quarkus as a first-class Simulatest integration. Tests in a Quarkus suite can write environments as Arc-managed
  beans with @Inject, use Panache in test methods, and still get per-test savepoint rollback. The integration does not
  rely on CDI alternative beans or synthetic-bean overrides; it slips in at the JDBC driver layer so Agroal, Hibernate,
  and Arc see a connection that is already Insistence-Layer-wrapped.

  Also extends the core to support pluggable environment lifecycles so plugins whose DI container starts after the
  engine's tree walk (Quarkus Arc, bootstrapped by QuarkusTestExtension.beforeAll) can produce environments through DI
  just like the Spring/Guice/JEE plugins do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Quarkus framework integration module with dependency injection support for test environments.
  * Introduced deferred environment execution strategy allowing environments to run after framework initialization.
  * Added configurable database schema management for test environments.
  * Added extensible configuration point for test database setup via service provider interface.

* **Tests**
  * Added comprehensive test coverage for new Quarkus integration and environment lifecycle features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->